### PR TITLE
Add ability to tx to run in a subfolder

### DIFF
--- a/internal/txlib/config/local.go
+++ b/internal/txlib/config/local.go
@@ -35,7 +35,7 @@ type Resource struct {
 }
 
 func loadLocalConfig() (*LocalConfig, error) {
-	localPath, err := getLocalPath()
+	localPath, err := findLocalPath("")
 	if err != nil {
 		return nil, err
 	}
@@ -419,6 +419,29 @@ func getLocalPath() (string, error) {
 	curDir, err := os.Getwd()
 	if err != nil {
 		return "", err
+	}
+	return filepath.Join(curDir, ".tx", "config"), nil
+}
+
+func findLocalPath(path string) (string, error) {
+	curDir := path
+	if path == "" {
+		dir, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		curDir = dir
+	}
+
+	fp := filepath.Join(curDir, ".tx", "config")
+	if _, err := os.Stat(fp); os.IsNotExist(err) {
+		curDir = filepath.Dir(curDir)
+		if curDir != "/" && curDir != "." {
+			return findLocalPath(curDir)
+		} else {
+			return "", nil
+		}
+
 	}
 	return filepath.Join(curDir, ".tx", "config"), nil
 }


### PR DESCRIPTION
Up until now, running `tx` was functioning with the assumption that was
run from the project root folder and that config was in this path.

With this change we enable someone to use `tx` from a subfolder of this
project and it will try recursively try to find the `.tx/config` file
until it hits a `/` or `.` based on `.Dir()` implementation.