### PR TITLE
Add installation script for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,22 @@
 
 ## Installation
 
-The easiest and preferred way to install the Transifex CLI is to download
+### Installing with a script (Linux/Mac)
+You can install the Transifex CLI by executing:
+
+```
+curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+```
+
+This script will:
+* Try to find the correct version for your system.
+* Download & extract the CLI to the current folder.
+* Check for a profile in one of `.profile, .bashrc, .bash_profile, .zshrc` and append `export PATH="<PWD result>:$PATH"`, so you can call 'tx' from any path.
+
+**Note:** You need to restart your terminal for the `PATH` changes to be applied.
+
+### Download from Github Releases (Linux/Mac/Windows)
+Another way to install the Transifex CLI is to download
 the latest version of the binary from GitHub
 [here](https://github.com/transifex/cli/releases).
 
@@ -17,7 +32,7 @@ Clone the [repository](https://github.com/transifex/cli) and go into the directo
 ```shell
 cd /path/to/transifex/cli
 ```
-
+### Building from source
 The default way to build the binary is
 
   ```shell

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+#
+# Script definetely inspired by
+#
+# https://github.com/nvm-sh/nvm/blob/master/install.sh
+# https://github.com/heroku/cli/blob/master/install-standalone.sh
+#
+
+{
+    echoerr() { echo "$@" 1>&2; }
+
+    try_profile() {
+        if [ -z "${1-}" ] || [ ! -f "${1}" ]; then
+            return 1
+        else
+            echo $1
+        fi
+    }
+
+    find_profile() {
+        local DETECTED_PROFILE
+        if [ "${SHELL#*bash}" != "$SHELL" ]; then
+            if [ -f "$HOME/.bashrc" ]; then
+                DETECTED_PROFILE="$HOME/.bashrc"
+            elif [ -f "$HOME/.bash_profile" ]; then
+                DETECTED_PROFILE="$HOME/.bash_profile"
+            fi
+        elif [ "${SHELL#*zsh}" != "$SHELL" ]; then
+            if [ -f "$HOME/.zshrc" ]; then
+                DETECTED_PROFILE="$HOME/.zshrc"
+            fi
+        fi
+
+        if [ -z "$DETECTED_PROFILE" ]; then
+            for EACH_PROFILE in ".profile" ".bashrc" ".bash_profile" ".zshrc"; do
+                if DETECTED_PROFILE="$(try_profile "${HOME}/${EACH_PROFILE}")"; then
+                    break
+                fi
+            done
+        fi
+
+        if [ -n "$DETECTED_PROFILE" ]; then
+            echo "$DETECTED_PROFILE"
+        else
+            return 1
+        fi
+    }
+
+    # Get the latest version as string from Github API
+    LATEST_URL="https://api.github.com/repos/transifex/cli/releases/latest"
+    LATEST_VERSION="$(curl -s "$LATEST_URL" | grep "tag_name" |
+        cut -d : -f 2 | tr -d \"\,\ )"
+
+    # Try to figure out the version needed to download for the specific system
+
+    if [ "$(uname)" == "Darwin" ]; then
+        OS=darwin
+    elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+        OS=linux
+    else
+        echoerr "This installer is only supported on Linux and MacOS"
+        exit 1
+    fi
+
+    ARCH="$(uname -m)"
+    if [ "$ARCH" == "x86_64" ]; then
+        ARCH=amd64
+    elif [[ "$ARCH" == "aarch"* ]] || [[ "$ARCH" == "arm"* ]]; then
+        ARCH=arm64
+    elif [[ "$ARCH" == "i386" ]]; then
+        ARCH=386
+    else
+        echoerr "unsupported arch: $ARCH"
+        exit 1
+    fi
+
+    # Try to download the version from github releases
+    URL="https://github.com/transifex/cli/releases/download/$LATEST_VERSION/tx-$OS-$ARCH.tar.gz"
+
+    echo -e "** Installing CLI from $URL\n"
+    curl -L "$URL" | tar xz
+
+    # Try to add tx to PATH
+    echo -e "\n** Adding CLI to PATH"
+    DETECTED_PROFILE=$(find_profile)
+
+    if [ -n "$DETECTED_PROFILE" ]; then
+        echo "export PATH=\"$PWD:\$PATH\"" >> "$DETECTED_PROFILE"
+        echo "** export PATH=\"$PWD:\$PATH\" was added to $DETECTED_PROFILE. Please restart your terminal to have access to 'tx' from any path."
+    else
+        echo "** Profile not found, we tried for .profile, .bashrc, .bash_profile, .zshrc"
+        echo "** Please add this line to the correct file if you want to access 'tx' from any path."
+        echo -e "\nexport PATH=\"$PWD:\$PATH\"\n"
+    fi
+
+    echo -e "\n** If everything went fine you should see the Transifex CLI version in the following line."
+    ./tx -v
+}


### PR DESCRIPTION
This is a first approach of providing a shell script that can be used to install CLI from a terminal instance either in CI or a personal system. This addresses #14 

What it does (from documentation)
```
This script will:
* Try to find the correct version for your system.
* Download & extract the CLI to the current folder.
* Check for a profile in one of `.profile, .bashrc, .bash_profile, .zshrc` and append `export PATH="<PWD result>:$PATH"`, so you can call 'tx' from any path.
```

The way this works is:
* By using curl to `https://api.github.com/repos/transifex/cli/releases/latest` and `grep` for the `tag_name` key and its value to get the latest version `vx.x.x` so we can construct the download url at a later stage.
* By trying to find the system and arch so we can construct the download url at a later stage.
* Downloads/Unzips the asset
* Tries to find a profile file to add `tx` in path from a list of files (mentioned above)
* As a last step runs `./tx -v` to test if the correct binary was downloaded.

**Note:** The `curl` should happen on the `master` branch file so we can be able to make changes in `devel` without affecting users and just merge to `master` when we are ready.