### PR TITLE
Fix issue with paths on action from different OS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,5 @@ jobs:
            else
                 make local-test
            fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TKN }}

--- a/internal/txlib/file_filter_test.go
+++ b/internal/txlib/file_filter_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/transifex/cli/pkg/assert"
 )
 
 func beforeFileFilterTest(t *testing.T) func() {
@@ -121,4 +123,19 @@ func TestSearchFileFilterDirs(t *testing.T) {
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Got '%+v', expected '%+v'", actual, expected)
 	}
+}
+
+func TestNormaliseFileFilterLinuxBased(t *testing.T) {
+	result := normaliseFileFilter("en/text.txt")
+	expected := filepath.Join("en", "text.txt")
+
+	assert.Equal(t, result, expected)
+}
+
+func TestNormaliseFileFilterWinBased(t *testing.T) {
+
+	result := normaliseFileFilter("en\\text.txt")
+	expected := filepath.Join("en", "text.txt")
+
+	assert.Equal(t, result, expected)
 }

--- a/internal/txlib/filefilter.go
+++ b/internal/txlib/filefilter.go
@@ -129,8 +129,9 @@ The following calls and results will happen:
 func searchFileFilter(root string, fileFilter string) map[string]string {
 	result := make(map[string]string)
 
-	fileFilterSlice := strings.Split(fileFilter, PathSeparator)
+	fileFilter = normaliseFileFilter(fileFilter)
 
+	fileFilterSlice := strings.Split(fileFilter, PathSeparator)
 	if len(fileFilter) == 0 {
 		fileInfo, err := os.Stat(root)
 		if err != nil || fileInfo.IsDir() {
@@ -181,4 +182,20 @@ func searchFileFilter(root string, fileFilter string) map[string]string {
 		}
 		return result
 	}
+}
+
+/**
+Best effort try to figure out if we need to change the path separator
+Case: Someone creates the config paths for a linux machine but
+tries to use the CLI from a windows machine or the opposite
+*/
+func normaliseFileFilter(fileFilter string) string {
+	if !strings.Contains(fileFilter, PathSeparator) {
+		sep := "/"
+		if PathSeparator == "/" {
+			sep = "\\"
+		}
+		fileFilter = strings.Replace(fileFilter, sep, PathSeparator, -1)
+	}
+	return fileFilter
 }

--- a/internal/txlib/push.go
+++ b/internal/txlib/push.go
@@ -456,7 +456,11 @@ func pushTranslations(
 			return nil, err
 		}
 	}
-
+	if len(languageCodesToPush) < 1 {
+		spinner.Warning(
+			fmt.Sprintf("No language files found to push. Aborting"),
+		)
+	}
 	var uploads []*jsonapi.Resource
 	for i := range languageCodesToPush {
 		languageCode := languageCodesToPush[i]


### PR DESCRIPTION
This solves a case when a user tries to make an action (pull/push) from
an OS that has different path separator from the one that was set in
`config`.

Example:

`config`

```
...
file_filter = src/static/_locales/<lang>/messages.json
...
```

When the user tries to push or pull from a Windows machine, this will
fail due to the way we search the `searchFileFilter` recursively
searches for files (`os.PathSeparator`).

The current fix tries to find if the `os.PathSeparator` is contained
in the path and replaces with the alternative.

In the specific example we will search for `\` which is the OS separator
and since there is no occurrence we will replace `/` with `\` and we
will be able to locate the files. This should also apply when we have a
Windows `file_filter` and a Linux based machine that tries to make an
action.

An additional message that we didn't find any translation files was
added to provide more context to the user.