### PR TITLE
Fix issue when testing empty dir exists

### DIFF
--- a/pkg/txapi/resource_strings_async_downloads.go
+++ b/pkg/txapi/resource_strings_async_downloads.go
@@ -70,9 +70,11 @@ func PollResourceStringsDownload(
 
 			dir, _ := filepath.Split(cfgResource.SourceFile)
 
-			if _, statErr := os.Stat(dir); os.IsNotExist(statErr) {
-				err := fmt.Errorf("directory '%s' does not exist", dir)
-				return err
+			if dir != "" {
+				if _, statErr := os.Stat(dir); os.IsNotExist(statErr) {
+					err := fmt.Errorf("directory '%s' does not exist", dir)
+					return err
+				}
 			}
 
 			sourceFile := cfgResource.SourceFile


### PR DESCRIPTION
When pulling, we check if the directory of the source file exists.
In case the path is the current directory, this fails and returns that
directory doesn't exist. #24 

Example:

```
source_file  = cli.txt
```

`filepath.Split(cfgResource.SourceFile)` will return an empty string
and `if _, statErr := os.Stat(dir); os.IsNotExist(statErr)` will return
an error that the `directory '' does not exist`.

This fix will check first if the `dir` is not empty (current directory)
and then proceed to check if it exists.