### PR TITLE
Add branch name at the beginning of resource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ configured with `tx add`.
 
 **Limiting resources:**
 
-You can limit the resources you want to pull with:
+You can limit the resources you want to push with:
 
 ```sh
 → tx push [RESOURCE_ID]...
@@ -365,7 +365,7 @@ default to taking the filesystem timestamp into account.
   resource that are tied to the provided branch. So if `tx push proj.res`
   pushes to the `https://www.transifex.com/org/proj/res` resource, then `tx
   push --branch foo proj.res` will push to the
-  `https://www.transifex.com/org/proj/res--foo` resource. This way you can
+  `https://www.transifex.com/org/proj/foo--res` resource. This way you can
   separate the localization effort across different branches. If you supply an
   empty string as the branch (`--branch ''`), then the client will attempt to
   figure out the currently active branch in the local git repository. For
@@ -384,7 +384,7 @@ default to taking the filesystem timestamp into account.
   `https://www.transifex.com/myorganization/myproject/myresource` resource will
   not be affected by the changes you did to the source strings and the
   localization effort can be done in parallel on the
-  `https://www.transifex.com/myorganization/myproject/myresource--new_feature`
+  `https://www.transifex.com/myorganization/myproject/new_feature--myresource`
   resource.
 
 - `--skip`: Normally, if an upload fails, the client will abort. This may not
@@ -545,7 +545,7 @@ default to taking the filesystem timestamp into account.
   resource that are tied to the provided branch. So if `tx pull proj.res`
   pulls from the `https://www.transifex.com/org/proj/res` resource, then `tx
   pull --branch foo proj.res` will pull from the
-  `https://www.transifex.com/org/proj/res--foo` resource. This way you can
+  `https://www.transifex.com/org/proj/foo--res` resource. This way you can
   separate the localization effort across different branches. If you supply an
   empty string as the branch (`--branch ''`), then the client will attempt to
   figure out the currently active branch in the local git repository. For

--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -592,7 +592,7 @@ func Main() {
 					},
 					&cli.StringFlag{
 						Name: "branch",
-						Usage: "Push to specific branch (use empty argument " +
+						Usage: "Delete specific branch (use empty argument " +
 							"'' to use the current branch, if it can be " +
 							"determined)",
 						Value: "-1",

--- a/internal/txlib/delete.go
+++ b/internal/txlib/delete.go
@@ -94,8 +94,8 @@ func DeleteCommand(
 		cfgResource := *item
 		if arguments.Branch != "" {
 			cfgResource.ResourceSlug = fmt.Sprintf("%s--%s",
-				cfgResource.ResourceSlug,
-				slug.Make(arguments.Branch))
+				slug.Make(arguments.Branch),
+				cfgResource.ResourceSlug)
 		}
 		err := deleteResource(&api, cfg, cfgResource, *arguments)
 		if err != nil {

--- a/internal/txlib/delete_test.go
+++ b/internal/txlib/delete_test.go
@@ -19,9 +19,9 @@ const (
 	resourcesUrlDeleteCommand = "/resources?filter%5B" +
 		"project%5D=o%3Aorgslug%3Ap%3Aprojslug"
 	resourceUrlDeleteCommand              = "/resources/o:orgslug:p:projslug:r:resslug"
-	resourceUrlBranchDeleteCommand        = "/resources/o:orgslug:p:projslug:r:resslug--abranch"
+	resourceUrlBranchDeleteCommand        = "/resources/o:orgslug:p:projslug:r:abranch--resslug"
 	resource1UrlDeleteCommand             = "/resources/o:orgslug:p:projslug:r:resslug1"
-	resource1UrlBranchDeleteCommand       = "/resources/o:orgslug:p:projslug:r:resslug1--abranch"
+	resource1UrlBranchDeleteCommand       = "/resources/o:orgslug:p:projslug:r:abranch--resslug1"
 	resourceLanguageStatsUrlDeleteCommand = "/resource_language_stats?" +
 		"filter%5Bproject%5D=o%3Aorgslug%3Ap%3Aprojslug&" +
 		"filter%5Bresource%5D=o%3Aorgslug%3Ap%3Aprojslug%3Ar%3Aresslug"
@@ -493,8 +493,8 @@ func deleteGetResourceBranchEndpoint() *jsonapi.MockEndpoint {
 		Requests: []jsonapi.MockRequest{{
 			Response: jsonapi.MockResponse{
 				Text: `{"data": {"type": "resources",
-								 "id": "o:orgslug:p:projslug:r:resslug--abranch",
-								 "attributes": {"slug": "resslug--abranch"}}}`,
+								 "id": "o:orgslug:p:projslug:r:abranch--resslug",
+								 "attributes": {"slug": "abranch--resslug"}}}`,
 			},
 		}},
 	}
@@ -517,8 +517,8 @@ func deleteGetResourceBranch1Endpoint() *jsonapi.MockEndpoint {
 		Requests: []jsonapi.MockRequest{{
 			Response: jsonapi.MockResponse{
 				Text: `{"data": {"type": "resources",
-								 "id": "o:orgslug:p:projslug:r:resslug1--branch",
-								 "attributes": {"slug": "resslug1--branch"}}}`,
+								 "id": "o:orgslug:p:projslug:r:branch--resslug1",
+								 "attributes": {"slug": "branch--resslug1"}}}`,
 			},
 		}},
 	}
@@ -551,15 +551,15 @@ func deleteGetResourcesBranchEndpoint() *jsonapi.MockEndpoint {
 			{
 				Response: jsonapi.MockResponse{
 					Text: `{"data": [{"type": "resources",
-									"id": "o:orgslug:p:projslug:r:resslug--abranch",
-									"attributes": {"slug": "resslug--abranch"}}]}`,
+									"id": "o:orgslug:p:projslug:r:abranch--resslug",
+									"attributes": {"slug": "abranch--resslug"}}]}`,
 				},
 			},
 			{
 				Response: jsonapi.MockResponse{
 					Text: `{"data": [{"type": "resources",
-									"id": "o:orgslug:p:projslug:r:resslug1--abranch",
-									"attributes": {"slug": "resslug1--abranch"}}]}`,
+									"id": "o:orgslug:p:projslug:r:abranch--resslug1",
+									"attributes": {"slug": "abranch--resslug1"}}]}`,
 				},
 			},
 		},

--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -67,7 +67,7 @@ func PullCommand(
 			}
 			if arguments.Branch != "" {
 				key := fmt.Sprintf("%s--%s",
-					cfgResource.Name(), arguments.Branch)
+					arguments.Branch, cfgResource.Name())
 				cfgResources[key] = cfgResource
 			} else {
 				cfgResources[cfgResource.Name()] = cfgResource
@@ -80,7 +80,7 @@ func PullCommand(
 			cfgResource := &cfg.Local.Resources[i]
 			if arguments.Branch != "" {
 				key := fmt.Sprintf("%s--%s",
-					cfgResource.Name(), arguments.Branch)
+					arguments.Branch, cfgResource.Name())
 				cfgResources[key] = cfgResource
 			} else {
 				cfgResources[cfgResource.Name()] = cfgResource
@@ -92,8 +92,8 @@ func PullCommand(
 		cfgResource := cfgResources[i]
 		if arguments.Branch != "" {
 			cfgResource.ResourceSlug = fmt.Sprintf("%s--%s",
-				cfgResource.ResourceSlug,
-				arguments.Branch)
+				arguments.Branch,
+				cfgResource.ResourceSlug)
 		}
 	}
 

--- a/internal/txlib/push.go
+++ b/internal/txlib/push.go
@@ -115,8 +115,8 @@ func PushCommand(
 		cfgResource := cfgResources[i]
 		if args.Branch != "" {
 			cfgResource.ResourceSlug = fmt.Sprintf("%s--%s",
-				cfgResource.ResourceSlug,
-				slug.Make(args.Branch))
+				slug.Make(args.Branch),
+				cfgResource.ResourceSlug)
 		}
 	}
 
@@ -210,9 +210,9 @@ func pushResource(
 		if args.Branch == "" {
 			resourceName = cfgResource.ResourceName()
 		} else {
-			resourceName = fmt.Sprintf("%s (branch %s)",
-				cfgResource.ResourceName(),
-				args.Branch)
+			resourceName = fmt.Sprintf("(branch %s) %s",
+				args.Branch,
+				cfgResource.ResourceName())
 		}
 		msg = fmt.Sprintf(
 			"Creating resource with name '%s' and slug '%s'",

--- a/internal/txlib/push_test.go
+++ b/internal/txlib/push_test.go
@@ -486,8 +486,8 @@ func TestPushCommandBranch(t *testing.T) {
 				Response: jsonapi.MockResponse{
 					Text: `{"data": {
 						"type": "resources",
-						"id": "o:orgslug:p:projslug:r:resslug--branch",
-						"attributes": {"slug": "resslug--branch"}
+						"id": "o:orgslug:p:projslug:r:branch--resslug",
+						"attributes": {"slug": "branch--resslug"}
 					}}`,
 				},
 			}},
@@ -510,8 +510,8 @@ func TestPushCommandBranch(t *testing.T) {
 	testSimpleGet(t, mockData, resourcesUrl)
 	testSimplePost(t, mockData, "/resources", `{"data": {
 		"type": "resources",
-		"attributes": {"name": "aaa.json (branch branch)",
-					   "slug": "resslug--branch"},
+		"attributes": {"name": "(branch branch) aaa.json",
+					   "slug": "branch--resslug"},
 		"relationships": {
 			"project": {"data": {"type": "projects",
 								 "id": "o:orgslug:p:projslug"}},


### PR DESCRIPTION
We transpose the branch name before the resource
name to be compatible with the old Python client.

With the change the slug of a resource, when using --branch option,
is:
	`<branch name>--<resource slug>`

instead of the previous behaviour:
	`<resource-slug>--<branch name>`