### PR TITLE
Batch of bugs and enhancements

### DIFF
--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -48,7 +48,8 @@ func Main() {
 		},
 	}
 	app := &cli.App{
-		Version: txlib.Version,
+		Version:                txlib.Version,
+		UseShortOptionHandling: true,
 		Commands: []*cli.Command{
 			{
 				Name:    "migrate",

--- a/internal/txlib/migrate.go
+++ b/internal/txlib/migrate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/transifex/cli/pkg/txapi"
@@ -110,7 +111,15 @@ func MigrateLegacyConfigFile(
 				)
 			} else {
 				resource.OrganizationSlug = organizationSlug
+				if resource.SourceFile == "" &&
+					resource.SourceLanguage != "" &&
+					resource.FileFilter != "" {
+					resource.SourceFile = strings.ReplaceAll(
+						resource.FileFilter, "<lang>", resource.SourceLanguage,
+					)
+				}
 				resources[i] = resource
+
 			}
 
 		}

--- a/internal/txlib/migrate_test.go
+++ b/internal/txlib/migrate_test.go
@@ -299,6 +299,158 @@ func TestSuccessfulMigration(t *testing.T) {
 	assert.Equal(t, len(cfgReloaded.Local.Resources[0].Overrides), 2)
 }
 
+func TestSuccessfulMigrationWithSourceFileConstruction(t *testing.T) {
+	var afterTest = func(pkgDir string, tmpDir string) {
+		err := os.Chdir(pkgDir)
+		if err != nil {
+			t.Error(err)
+		}
+		err = os.RemoveAll(tmpDir)
+		if err != nil {
+			fmt.Println("Delete error:", err)
+		}
+	}
+
+	// Requests Data
+	org1ProjectsUrl := "/projects?filter%5Borganization%5D=o%3Aorg&" +
+		"filter%5Bslug%5D=projslug"
+	org2ProjectsUrl := "/projects?filter%5Borganization%5D=o%3Aorg2&" +
+		"filter%5Bslug%5D=projslug"
+	mockData := jsonapi.MockData{
+		"/organizations": &jsonapi.MockEndpoint{
+			Requests: []jsonapi.MockRequest{
+				{
+					Response: jsonapi.MockResponse{
+						Text: `{"data": [
+							{"type": "organizations",
+							 "id": "o:org",
+							 "attributes": {"slug": "org"}},
+							{"type": "organizations",
+							 "id": "o:org2",
+							 "attributes": {"slug": "org2"}}
+						]}`,
+					},
+				},
+			},
+		},
+		org1ProjectsUrl: &jsonapi.MockEndpoint{
+			Requests: []jsonapi.MockRequest{
+				{
+					Response: jsonapi.MockResponse{
+						Text: `{"data": [{
+							"type": "projects",
+							"id": "o:orgslug:p:projslug",
+							"attributes": {"name": "Proj Name",
+							               "slug": "projslug"},
+							"relationships": {"organization": {
+								"data": {"type": "organizations",
+										 "id": "o:orgslug"},
+								"links": {
+									"related": "/organizations/o:orgslug"
+								}
+							}}
+					}]}`,
+					},
+				},
+			},
+		},
+		org2ProjectsUrl: &jsonapi.MockEndpoint{
+			Requests: []jsonapi.MockRequest{
+				{
+					Response: jsonapi.MockResponse{
+						Text: `{"data": []}`,
+					},
+				},
+			},
+		},
+	}
+
+	// Create deprecated config & .transifexrc
+	pkgDir, _ := os.Getwd()
+	tmpDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = os.Chdir(tmpDir)
+	if err != nil {
+		t.Error(err)
+	}
+	defer afterTest(pkgDir, tmpDir)
+
+	f, err := os.Create(".transifexrc")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer f.Close()
+
+	_, err2 := f.WriteString(`
+		[https://www.transifex.com]
+		api_hostname  = https://api.transifex.com
+		hostname      = https://www.transifex.com
+		username      = api
+		password      = apassword
+	`)
+
+	if err2 != nil {
+		log.Fatal(err2)
+	}
+
+	f, err = os.Create("config")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer f.Close()
+
+	_, err2 = f.WriteString(`
+		[main]
+		host = https://www.transifex.com
+		[projslug.ares]
+		file_filter = locale/<lang>.po
+		minimum_perc = 0
+		source_lang = en
+		type = PO
+		trans.pt-pt = locale/other/pt_PT/en.po
+		trans.fr_CA = locale/other/fr_CA/ui.po
+	`)
+	if err2 != nil {
+		log.Fatal(err2)
+	}
+
+	// Load for the first time configs
+	cfg, err := config.LoadFromPaths(
+		filepath.Join(tmpDir, ".transifexrc"), filepath.Join(tmpDir, "config"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	api := jsonapi.GetTestConnection(mockData)
+
+	assert.Equal(t, cfg.GetActiveHost().Token, "")
+	assert.Equal(t, cfg.GetActiveHost().RestHostname, "")
+	assert.Equal(t, cfg.Local.Resources[0].OrganizationSlug, "")
+
+	_, err = MigrateLegacyConfigFile(&cfg, api)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Load for the first time configs
+	cfgReloaded, err := config.LoadFromPaths(
+		filepath.Join(tmpDir, ".transifexrc"), filepath.Join(tmpDir, "config"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, cfgReloaded.Local.Resources[0].OrganizationSlug, "org")
+	assert.Equal(t, cfgReloaded.Local.Resources[0].SourceFile, "locale/en.po")
+	assert.Equal(t, len(cfgReloaded.Local.Resources[0].Overrides), 2)
+}
+
 func TestNeedsTokenInRootConfig(t *testing.T) {
 	var afterTest = func(pkgDir string, tmpDir string) {
 		err := os.Chdir(pkgDir)

--- a/pkg/txapi/resource_translations_async_downloads.go
+++ b/pkg/txapi/resource_translations_async_downloads.go
@@ -82,7 +82,7 @@ func PollTranslationDownload(languageMappings map[string]string,
 			}
 			txLanguageCode := languageRelationship.DataSingular.Attributes["code"].(string)
 
-			localLanguageCode, languageDirectory := CreateLanguageDirectory(
+			localLanguageCode, languageDirectory := GetLanguageDirectory(
 				languageMappings,
 				txLanguageCode,
 				cfgResource)
@@ -127,7 +127,7 @@ func PollTranslationDownload(languageMappings map[string]string,
 	return nil
 }
 
-func CreateLanguageDirectory(
+func GetLanguageDirectory(
 	languageMappings map[string]string,
 	txLanguageCode string,
 	cfgResource *config.Resource,


### PR DESCRIPTION
* Enable command shorthand combination 
Implemented as described in [urfave/cli](https://github.com/urfave/cli/blob/master/docs/v2/manual.md#combining-short-options)
(should solve #27)

* Fix migration issue with `SourceFile` 
There seems to be cases that source_file is omitted from `config` and
the combination of `file_filter` and `source_language` was used.
In order not to break users' migrations, during the migration script we
check if the `source_file` exists and if not we try to create it with
the `file_filter` and `source_language`.
(should solve #35)

* Fix issue that "-f" affects "minimum-perc" 
Minimum percentage checks should not be affected by the force flag.
For this to be solved in order to get to the "shouldSkipDownload"
method, we take under consideration also the minimum-perc and
"shouldSkipDownload" also is aware of the force flag in order to decide
which checks it will make.
If minimum-perc exists and fails the checks, then the pull for the
specific resource will fail, even if force flag is true.
Also `CreateLanguageDirectory` method was renamed to 
`GetLanguageDirectory` to better reflect its functionality.
(should solve #36)