### PR TITLE
Use default fg color instead of hard-coded white

### DIFF
--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -114,14 +114,13 @@ func (task *ResourcePullTask) Run(send func(string), abort func()) {
 	filePullTaskChannel := task.filePullTaskChannel
 	cfg := task.cfg
 
-	white := color.New(color.FgWhite).SprintFunc()
 
 	sendMessage := func(body string) {
 		send(fmt.Sprintf(
 			"%s.%s - %s",
 			cfgResource.ProjectSlug,
 			cfgResource.ResourceSlug,
-			white(body),
+			body,
 		))
 	}
 	sendMessage("Getting info")
@@ -314,13 +313,12 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 		}
 
 		cyan := color.New(color.FgCyan).SprintFunc()
-		white := color.New(color.FgWhite).SprintFunc()
 		send(fmt.Sprintf(
 			"%s.%s %s - %s",
 			cfgResource.ProjectSlug,
 			cfgResource.ResourceSlug,
 			cyan("["+code+"]"),
-			white(body),
+			body,
 		))
 	}
 	sendMessage("Pulling file")

--- a/internal/txlib/push.go
+++ b/internal/txlib/push.go
@@ -211,13 +211,12 @@ func (task *ResourcePushTask) Run(send func(string), abort func()) {
 	args := task.args
 	targetLanguagesChannel := task.targetLanguagesChannel
 
-	white := color.New(color.FgWhite).SprintFunc()
 	sendMessage := func(body string) {
 		send(fmt.Sprintf(
 			"%s.%s - %s",
 			cfgResource.ProjectSlug,
 			cfgResource.ResourceSlug,
-			white(body),
+			body,
 		))
 	}
 	sendMessage("Getting info")
@@ -450,9 +449,8 @@ func (task *SourceFilePushTask) Run(send func(string), abort func()) {
 	resourceIsNew := task.resourceIsNew
 
 	parts := strings.Split(resource.Id, ":")
-	white := color.New(color.FgWhite).SprintFunc()
 	sendMessage := func(body string) {
-		send(fmt.Sprintf("%s.%s - %s", parts[3], parts[5], white(body)))
+		send(fmt.Sprintf("%s.%s - %s", parts[3], parts[5], body))
 	}
 
 	file, err := os.Open(sourceFile)
@@ -545,11 +543,10 @@ func (task *TranslationFileTask) Run(send func(string), abort func()) {
 
 	parts := strings.Split(resource.Id, ":")
 	cyan := color.New(color.FgCyan).SprintFunc()
-	white := color.New(color.FgWhite).SprintFunc()
 	sendMessage := func(body string) {
 		send(fmt.Sprintf(
 			"%s.%s %s - %s", parts[3], parts[5],
-			cyan("["+languageCode+"]"), white(body),
+			cyan("["+languageCode+"]"), body,
 		))
 	}
 


### PR DESCRIPTION
The choice of having hard-coded white color for some of the output text in the `pull` and `push` commands leads to a poor user experience for people who use a light theme in their terminals.

Using the terminal's default foreground color instead should get around this problem.

Here's what version 1.2.0 looks like for me, for example: 
![Screenshot from 2022-06-29 15-22-52](https://user-images.githubusercontent.com/2308/176449221-9ba427c0-fb37-467a-872e-639a8b68a177.png)

Here's what it looks like with this patch: 
![Screenshot from 2022-06-29 15-36-55](https://user-images.githubusercontent.com/2308/176450055-1de9b7fb-b0a0-427e-9e90-70448be1c17d.png)

