### PR TITLE
Fix issue with tar inconsistency

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,12 @@
     URL="https://github.com/transifex/cli/releases/download/$LATEST_VERSION/tx-$OS-$ARCH.tar.gz"
 
     echo -e "** Installing CLI from $URL\n"
-    curl -L "$URL" | tar xz --skip-old-files
+    if tar --version | grep -q 'gnu'
+    then
+        curl -L "$URL" | tar xz --skip-old-files
+    else
+        curl -L "$URL" | tar kxz
+    fi
 
     # Try to add tx to PATH
     echo -e "\n** Adding CLI to PATH"


### PR DESCRIPTION
This introduces a condition in the installation script that tries to
identify if the tar implementation is GNU.
If not, the script fallbacks to a `bsdtar` compatible command.

The reason behind this change is that `--skip-old-files` is not
available in `bsdtar` but a `-k, --keep-old-files` which has the same
result is.

Should tackle #70 

**How to test**

There are two ways to test this script (in a linux and a Mac OS X system)
1. Get the branch and run the `install.sh` script.
2. If you don't want to get the branch, just run `curl -o- https://raw.githubusercontent.com/transifex/cli/e70f2963a953fef37b787f4bddf65fed65fd254a/install.sh | bash`.

**Note:** If we get more of these issues, we may need to drop the markdown files from the releases or figure out a different approach.