### PR TITLE
Bump staticcheck version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@2022.1
+        run: go install honnef.co/go/tools/cmd/staticcheck@2022.1.3
       - name: Run staticcheck
         run: staticcheck ./...


### PR DESCRIPTION
This is a test to see that new errors will arise with the new staticcheck. A new commit is meant to fix them