### PR TITLE
Abort source pulls (wihtout '-t') with languages

### DIFF
--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -461,6 +461,15 @@ func Main() {
 						), 1)
 					}
 
+					if !arguments.Translations &&
+						(arguments.All || len(arguments.Languages) > 0) {
+						return cli.Exit(errorColor(
+							"It doesn't make sense to use the '--all' or "+
+								"'--language' flag without the "+
+								"'--translation' flag",
+						), 1)
+					}
+
 					err = txlib.PullCommand(&cfg, &api, &arguments)
 					if err != nil {
 						return cli.Exit(err, 1)


### PR DESCRIPTION
This check existed in `tx push` but for some reason we neglected to copy it to `tx pull`.

Mentioned in #91 