### PR TITLE
Rename the `translation` flag for `tx pull`

### DIFF
--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -324,7 +324,7 @@ func Main() {
 						Usage:   "Download source file only",
 					},
 					&cli.BoolFlag{
-						Name:    "translations",
+						Name:    "translation",
 						Aliases: []string{"t"},
 						Usage:   "Downloads translations files (default)",
 					},
@@ -421,7 +421,7 @@ func Main() {
 						Force:             c.Bool("force"),
 						Skip:              c.Bool("skip"),
 						Source:            c.Bool("source"),
-						Translations:      c.Bool("translations"),
+						Translation:       c.Bool("translation"),
 						DisableOverwrite:  c.Bool("disable-overwrite"),
 						All:               c.Bool("all"),
 						ResourceIds:       resourceIds,
@@ -471,7 +471,7 @@ func Main() {
 						), 1)
 					}
 
-					if !arguments.Translations &&
+					if !arguments.Translation &&
 						(arguments.All || len(arguments.Languages) > 0) {
 						return cli.Exit(errorColor(
 							"It doesn't make sense to use the '--all' or "+

--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -23,7 +23,7 @@ type PullCommandArguments struct {
 	Skip              bool
 	Languages         []string
 	Source            bool
-	Translations      bool
+	Translation       bool
 	All               bool
 	DisableOverwrite  bool
 	ResourceIds       []string
@@ -201,7 +201,7 @@ func (task *ResourcePullTask) Run(send func(string), abort func()) {
 	sourceLanguage := project.Relationships["source_language"].DataSingular
 
 	var stats map[string]*jsonapi.Resource
-	if args.Source && !args.Translations {
+	if args.Source && !args.Translation {
 		stats, err = txapi.GetResourceStats(api, resource, sourceLanguage)
 	} else {
 		stats, err = txapi.GetResourceStats(api, resource, nil)
@@ -227,7 +227,7 @@ func (task *ResourcePullTask) Run(send func(string), abort func()) {
 		}
 	}
 
-	if args.Translations || !args.Source {
+	if args.Translation || !args.Source {
 		languageInfo := make(map[string]*struct {
 			filePath string
 			stats    *jsonapi.Resource


### PR DESCRIPTION
Rename from `translations` to `translation`.

This keeps it consistent with the `tx push` command and documentation.

But it is a breaking change.