### PR TITLE
Introducing support for multiple `<lang>` parameters in `tx pull` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ The options for this command are:
 
   - `<project_slug>`
   - `<resource_slug>` _(required)_
-  - `<lang>` _(required)_
+  - `<lang>` _(required)_ - can be used multiple times in the filter path
   - `<ext>`
 
   The default value for this option is

--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -461,7 +461,7 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 				cfgResource.FileFilter,
 				"<lang>",
 				localLanguageCode,
-				1,
+				-1,
 			)
 			filePath = setFileTypeExtensions(args.FileType, filePath)
 		}

--- a/internal/txlib/pull_test.go
+++ b/internal/txlib/pull_test.go
@@ -281,7 +281,7 @@ func TestPullCommandOverrides(t *testing.T) {
 	testSimpleTranslationDownload(t, mockData)
 	testSimpleGet(t, mockData, translationDownloadUrl)
 
-	assertFileContent(t, "aaa-el.json", "This is the content")
+	assertFileContent(t, "custom_path.json", "This is the content")
 }
 
 func TestPullCommandMultipleLangParameters(t *testing.T) {


### PR DESCRIPTION
## Description
Introducing support for multiple `<lang>` parameters in `tx pull` command.

The `tx pull` command does not support multiple `<lang>` parameters at the moment, whereas other commands (eg. `tx add` does it already - see related PR https://github.com/transifex/cli/pull/92).

With the following configuration:
```
[o:org:p:project:r:other-test-resource]
file_filter  = locale/<lang>/other-test-resource.<lang>.yaml
source_file  = locale/en/other-test-resource.en.yaml
type         = YAML_GENERIC
```

I get following output:
![Screen Shot 2022-10-12 at 4 03 37 PM](https://user-images.githubusercontent.com/7738501/195364573-580c58ed-0808-49f5-ac01-196c208a3157.png)


And the expected behavior is this:
![Screen Shot 2022-10-12 at 4 02 35 PM](https://user-images.githubusercontent.com/7738501/195364700-832cc6ba-76e6-4a93-9321-70752ef7653d.png)


