### PR TITLE
Fix hint about combining '--all' with '--translation'

### DIFF
--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -244,7 +244,7 @@ func Main() {
 						return cli.Exit(errorColor(
 							"It doesn't make sense to use the '--all' or "+
 								"'--language' flag without the "+
-								"'--translation' flag",
+								"'--translation' or '--translations' flag",
 						), 1)
 					}
 


### PR DESCRIPTION
Running `tx pull --all` currently shows the error:

> It doesn't make sense to use the '--all' or '--language' flag without the '--translation' flag

However, for `tx pull` the argument actually needs to be `--translations` (with an `s` at the end) and not `--translation` as it is for `tx push`.