### PR TITLE
Add download pseudo translations flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,8 @@ default to taking the filesystem timestamp into account.
   speed. The `--workers` flag sets the number of concurrent downloads possible at
   any time.
 
+- `--pseudo`: Generate mock string translations with a ~20% default length increase in characters.
+
 ### Removing resources from Transifex
 The tx delete command lets you delete a resource that's in your `config` file and on Transifex.
 

--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -482,6 +482,11 @@ func Main() {
 						Name:  "silent",
 						Usage: "Whether to reduce verbosity of the output",
 					},
+					&cli.BoolFlag{
+						Name:  "pseudo",
+						Usage: "Generate mock string translations",
+						Value: false,
+					},
 				},
 				Action: func(c *cli.Context) error {
 					cfg, err := config.LoadFromPaths(c.String("root-config"),
@@ -534,6 +539,7 @@ func Main() {
 						MinimumPercentage: c.Int("minimum-perc"),
 						Workers:           c.Int("workers"),
 						Silent:            c.Bool("silent"),
+						Pseudo:            c.Bool("pseudo"),
 					}
 
 					if c.Bool("xliff") && c.Bool("json") {

--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -32,6 +32,7 @@ type PullCommandArguments struct {
 	MinimumPercentage int
 	Workers           int
 	Silent            bool
+	Pseudo            bool
 }
 
 func PullCommand(
@@ -403,6 +404,7 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 					resource,
 					args.ContentEncoding,
 					args.FileType,
+					args.Pseudo,
 				)
 				return err
 			},
@@ -497,14 +499,24 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 		err = handleThrottling(
 			func() error {
 				var err error
-				download, err = txapi.CreateTranslationsAsyncDownload(
-					api,
-					resource,
-					languageCode,
-					args.ContentEncoding,
-					args.FileType,
-					args.Mode,
-				)
+				if args.Pseudo {
+					download, err = txapi.CreateResourceStringsAsyncDownload(
+						api,
+						resource,
+						args.ContentEncoding,
+						args.FileType,
+						args.Pseudo,
+					)
+				} else {
+					download, err = txapi.CreateTranslationsAsyncDownload(
+						api,
+						resource,
+						languageCode,
+						args.ContentEncoding,
+						args.FileType,
+						args.Mode,
+					)
+				}
 				return err
 			},
 			"Creating download job",

--- a/pkg/txapi/resource_strings_async_downloads.go
+++ b/pkg/txapi/resource_strings_async_downloads.go
@@ -17,6 +17,7 @@ func CreateResourceStringsAsyncDownload(
 	resource *jsonapi.Resource,
 	contentEncoding string,
 	fileType string,
+	pseudo bool,
 ) (*jsonapi.Resource, error) {
 	download := &jsonapi.Resource{
 		API:  api,
@@ -24,7 +25,7 @@ func CreateResourceStringsAsyncDownload(
 		Attributes: map[string]interface{}{
 			"content_encoding": contentEncoding,
 			"file_type":        fileType,
-			"pseudo":           false,
+			"pseudo":           pseudo,
 		},
 	}
 	download.SetRelated("resource", resource)


### PR DESCRIPTION
This uses the `pseudo` attribute in API to download
files with pseudo translations.

The change is on the pull command, in which, if
`pseudo` flag is true we use the source file
download instead of the translations file download
because for compatibility issues. The `pseudo`
attribute will be removed from the API for translations
in the future and will be used only in source.