### PR TITLE
Add pseudo to filename when needed

### DIFF
--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -455,10 +455,14 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 				sendMessage("File was not found locally, skipping", false)
 				return
 			}
+			pseudo_prefix := ""
+			if args.Pseudo {
+				pseudo_prefix = "pseudo_"
+			}
 			filePath = strings.Replace(
 				cfgResource.FileFilter,
 				"<lang>",
-				localLanguageCode,
+				pseudo_prefix+localLanguageCode,
 				-1,
 			)
 			filePath = setFileTypeExtensions(args.FileType, filePath)

--- a/internal/txlib/pull_test.go
+++ b/internal/txlib/pull_test.go
@@ -583,7 +583,7 @@ func TestDownloadPseudoTranslations(t *testing.T) {
 		t.Errorf("%s", err)
 	}
 
-	assertFileContent(t, "locale/el/aaa-el.json", "This is the content")
+	assertFileContent(t, "locale/pseudo_el/aaa-pseudo_el.json", "This is the content")
 	testSimpleGet(t, mockData, resourceUrl)
 	testSimpleGet(t, mockData, projectUrl)
 	testSimpleGet(t, mockData, statsUrlAllLanguages)


### PR DESCRIPTION
Emulate the behaviour of the old CLI regarding pseudo. The `<lang>` would be also replaced with a `pseudo_` prefix.

Since we can have multiple `<lang>`s in the filepath this means that there might be multiple `pseudo` occurrences.