### PR TITLE
Pseudo flag fixes

### DIFF
--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -580,6 +580,14 @@ func Main() {
 						)
 					}
 
+					if arguments.Pseudo && arguments.Source {
+						return cli.Exit(errorColor(
+							"It doesn't make sense to use the '--pseudo' flag with the "+
+								"CLI in \"source pull\" mode ('--source' flag). Please use with "+
+								" translation files.",
+						), 1)
+					}
+
 					if arguments.Source && !arguments.Translations &&
 						(arguments.All || len(arguments.Languages) > 0) {
 						return cli.Exit(errorColor(

--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -244,6 +244,14 @@ func (task *ResourcePullTask) Run(send func(string), abort func()) {
 			return
 		}
 		fileFilter := setFileTypeExtensions(args.FileType, cfgResource.FileFilter)
+		if args.Pseudo {
+			fileFilter = strings.Replace(
+				fileFilter,
+				"<lang>",
+				"<lang>_pseudo",
+				-1,
+			)
+		}
 		localFiles := searchFileFilter(".", fileFilter)
 
 		for localLanguageCode, filePath := range cfgResource.Overrides {


### PR DESCRIPTION
* Abort when source is used with pseudo
* Pass `pseudo` fix for local files