### PR TITLE
Fix issue with minimum-perc skip message

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ default to taking the filesystem timestamp into account.
   you set the `--skip` flag and an upload fails, then the client will simply
   print a warning and move on to the next language file.
 
-- `--minimum_perc=MINIMUM_PERC` Specify the minimum translation completion
+- `--minimum-perc=MINIMUM_PERC` Specify the minimum translation completion
   threshold required in order for a file to be downloaded.
 
 - `--workers/-w` (default 5, max 30): The client will pull files in parallel to improve


### PR DESCRIPTION
Before the fix, we were returning a message that a local file is newer than the remote one, which wasn't true.

This fix updates the `shouldSkipDownload` to return an additional value with a message in case it's different than the default one.

Also fixed a typo in readme regarding the `minimum-perc` flag.

Addresses #155 