### PR TITLE
Update disable-overwrite flag to create new files

### DIFF
--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -438,6 +438,11 @@ func Main() {
 						Usage:   "Whether skip existing files",
 					},
 					&cli.BoolFlag{
+						Name: "keep-new-files",
+						Usage: "Used with --disable-ovewrite to create new files " +
+							"if file already exists with a '.new' extension.",
+					},
+					&cli.BoolFlag{
 						Name:  "skip",
 						Usage: "Whether to skip on errors",
 					},
@@ -537,6 +542,7 @@ func Main() {
 						Source:            c.Bool("source"),
 						Translations:      c.Bool("translations"),
 						DisableOverwrite:  c.Bool("disable-overwrite"),
+						KeepNewFiles:      c.Bool("keep-new-files"),
 						All:               c.Bool("all"),
 						ResourceIds:       resourceIds,
 						UseGitTimestamps:  c.Bool("use-git-timestamps"),

--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -26,6 +26,7 @@ type PullCommandArguments struct {
 	Translations      bool
 	All               bool
 	DisableOverwrite  bool
+	KeepNewFiles      bool
 	ResourceIds       []string
 	UseGitTimestamps  bool
 	Branch            string
@@ -378,8 +379,12 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 
 		_, err := os.Stat(sourceFile)
 		if err == nil && args.DisableOverwrite {
-			sendMessage("Disable Overwrite is enabled, skipping", false)
-			return
+			if !args.KeepNewFiles {
+				sendMessage("Disable overwrite enabled, skipping", false)
+				return
+			} else {
+				sourceFile = sourceFile + ".new"
+			}
 		}
 
 		if !args.Force {
@@ -447,8 +452,12 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 		if filePath != "" {
 			// Remote language file exists and so does local
 			if args.DisableOverwrite {
-				sendMessage("Disable overwrite enabled, skipping", false)
-				return
+				if !args.KeepNewFiles {
+					sendMessage("Disable overwrite enabled, skipping", false)
+					return
+				} else {
+					filePath = filePath + ".new"
+				}
 			}
 		} else {
 			// Remote language file exists but local does not


### PR DESCRIPTION
This change extends the `disable-overwrite` flag to create
new remote files with a `.new` extension.

This was something supported in a previous version of the CLI and should work for translation and source files.