### PR TITLE
Append correct changes to disable-overwrite flag (revert)

### DIFF
--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -435,12 +435,8 @@ func Main() {
 					&cli.BoolFlag{
 						Name:    "disable-overwrite",
 						Aliases: []string{"d"},
-						Usage:   "Whether skip existing files",
-					},
-					&cli.BoolFlag{
-						Name: "keep-new-files",
-						Usage: "Used with --disable-ovewrite to create new files " +
-							"if file already exists with a '.new' extension.",
+						Usage: "Whether skip overwriting existing files" +
+							" and create remote files with a .new extension",
 					},
 					&cli.BoolFlag{
 						Name:  "skip",
@@ -542,7 +538,6 @@ func Main() {
 						Source:            c.Bool("source"),
 						Translations:      c.Bool("translations"),
 						DisableOverwrite:  c.Bool("disable-overwrite"),
-						KeepNewFiles:      c.Bool("keep-new-files"),
 						All:               c.Bool("all"),
 						ResourceIds:       resourceIds,
 						UseGitTimestamps:  c.Bool("use-git-timestamps"),

--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -26,7 +26,6 @@ type PullCommandArguments struct {
 	Translations      bool
 	All               bool
 	DisableOverwrite  bool
-	KeepNewFiles      bool
 	ResourceIds       []string
 	UseGitTimestamps  bool
 	Branch            string
@@ -379,12 +378,8 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 
 		_, err := os.Stat(sourceFile)
 		if err == nil && args.DisableOverwrite {
-			if !args.KeepNewFiles {
-				sendMessage("Disable overwrite enabled, skipping", false)
-				return
-			} else {
-				sourceFile = sourceFile + ".new"
-			}
+			sendMessage("Disable overwrite enabled, creating a .new file", false)
+			sourceFile = sourceFile + ".new"
 		}
 
 		if !args.Force {
@@ -452,12 +447,8 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 		if filePath != "" {
 			// Remote language file exists and so does local
 			if args.DisableOverwrite {
-				if !args.KeepNewFiles {
-					sendMessage("Disable overwrite enabled, skipping", false)
-					return
-				} else {
-					filePath = filePath + ".new"
-				}
+				sendMessage("Disable overwrite enabled, creating a .new file", false)
+				filePath = filePath + ".new"
 			}
 		} else {
 			// Remote language file exists but local does not
@@ -564,7 +555,12 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 			return
 		}
 	}
-	sendMessage("Done", false)
+	if !args.DisableOverwrite {
+		sendMessage("Done", false)
+	} else {
+		sendMessage("Done. File created with a .new extension", false)
+	}
+
 }
 
 func shouldSkipDownload(

--- a/internal/txlib/pull_test.go
+++ b/internal/txlib/pull_test.go
@@ -2,7 +2,6 @@ package txlib
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -622,7 +621,6 @@ func TestKeepNewFilesSource(t *testing.T) {
 			ResourceIds:       nil,
 			MinimumPercentage: -1,
 			Workers:           1,
-			KeepNewFiles:      true,
 			DisableOverwrite:  true,
 		},
 	)
@@ -638,56 +636,6 @@ func TestKeepNewFilesSource(t *testing.T) {
 
 	assertFileContent(t, "aaa.json.new", "New source")
 	assertFileContent(t, "aaa.json", "")
-}
-
-func TestKeepNewFilesSourceOnlyWithDisableOverride(t *testing.T) {
-	afterTest := beforeTest(t, nil, nil)
-	defer afterTest()
-
-	cfg := getStandardConfig()
-	assertFileContent(t, "aaa.json", "")
-
-	ts := getNewTestServer("New source")
-	defer ts.Close()
-
-	mockData := jsonapi.MockData{
-		resourceUrl:            getResourceEndpoint(),
-		projectUrl:             getProjectEndpoint(),
-		statsUrlSourceLanguage: getStatsEndpointSourceLanguage(),
-		sourceDownloadsUrl:     getSourceDownloadsEndpoint(),
-		sourceDownloadUrl:      getDownloadEndpoint(ts.URL),
-	}
-
-	api := jsonapi.GetTestConnection(mockData)
-	err := PullCommand(
-		cfg,
-		&api,
-		&PullCommandArguments{
-			FileType:          "default",
-			Mode:              "default",
-			Force:             true,
-			Source:            true,
-			ResourceIds:       nil,
-			MinimumPercentage: -1,
-			Workers:           1,
-			KeepNewFiles:      true,
-		},
-	)
-	if err != nil {
-		t.Errorf("%s", err)
-	}
-
-	testSimpleGet(t, mockData, resourceUrl)
-	testSimpleGet(t, mockData, projectUrl)
-	testSimpleGet(t, mockData, statsUrlSourceLanguage)
-	testSimpleSourceDownload(t, mockData, "false")
-	testSimpleGet(t, mockData, sourceDownloadUrl)
-
-	assertFileContent(t, "aaa.json", "New source")
-	_, err = ioutil.ReadFile("aaa.json.new")
-	if err == nil {
-		t.Error("File not exist because DisableOverwrite is not true")
-	}
 }
 
 func TestKeepNewFilesTranslation(t *testing.T) {
@@ -717,7 +665,6 @@ func TestKeepNewFilesTranslation(t *testing.T) {
 		ResourceIds:       nil,
 		MinimumPercentage: -1,
 		Workers:           1,
-		KeepNewFiles:      true,
 		DisableOverwrite:  true,
 	}
 


### PR DESCRIPTION
    Update disable-overwrite flag to create new files
    
    This change extends the `disable-overwrite` flag to create
    new remote files with a `.new` extension.
    
    This was something supported in a previous version of the CLI.