### PR TITLE
Migrate www.transifex.com to app.transifex.com in local and root config

### DIFF
--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -73,17 +73,31 @@ func Main() {
 						Client: client,
 					}
 
-					backUpFilePath, err := txlib.MigrateLegacyConfigFile(&cfg,
+					backUpFilePath, backUpRootFilePath, err := txlib.MigrateLegacyConfigFile(&cfg,
 						api)
 
 					if err != nil {
 						return cli.Exit(err, 1)
 					}
 					fmt.Printf(
-						"Migration ended! We have also created a backup "+
-							"file for your previous config file `%s`.\n",
+						"Migration ended! We have created a backup "+
+							"file for your previous `%s` at `%s`.\n",
+						cfg.Local.Path,
 						backUpFilePath,
 					)
+					if backUpRootFilePath != "" {
+						fmt.Printf(
+							"Additionally, we have created a backup "+
+								"file for your previous `%s` at `%s`.\n",
+							cfg.Root.Path,
+							backUpRootFilePath,
+						)
+					} else {
+						fmt.Printf(
+							"Additionally, we have created a new `%s` with your token.\n",
+							cfg.Root.Path,
+						)
+					}
 					return nil
 				},
 			},

--- a/internal/txlib/migrate_test.go
+++ b/internal/txlib/migrate_test.go
@@ -154,9 +154,9 @@ func TestSuccessfulMigration(t *testing.T) {
 	defer f.Close()
 
 	_, err2 := f.WriteString(`
-		[https://app.transifex.com]
+		[https://www.transifex.com]
 		api_hostname  = https://api.transifex.com
-		hostname      = https://app.transifex.com
+		hostname      = https://www.transifex.com
 		username      = api
 		password      = apassword
 	`)
@@ -175,7 +175,7 @@ func TestSuccessfulMigration(t *testing.T) {
 
 	_, err2 = f.WriteString(`
 		[main]
-		host = https://app.transifex.com
+		host = https://www.transifex.com
 		[projslug.ares]
 		file_filter = locale/<lang>.po
 		minimum_perc = 0
@@ -198,11 +198,12 @@ func TestSuccessfulMigration(t *testing.T) {
 
 	api := jsonapi.GetTestConnection(mockData)
 
+	assert.Equal(t, cfg.GetActiveHost().Name, "https://www.transifex.com")
 	assert.Equal(t, cfg.GetActiveHost().Token, "")
 	assert.Equal(t, cfg.GetActiveHost().RestHostname, "")
 	assert.Equal(t, cfg.Local.Resources[0].OrganizationSlug, "")
 
-	_, err = MigrateLegacyConfigFile(&cfg, api)
+	_, _, err = MigrateLegacyConfigFile(&cfg, api)
 	if err != nil {
 		t.Error(err)
 	}
@@ -214,6 +215,7 @@ func TestSuccessfulMigration(t *testing.T) {
 		t.Error(err)
 	}
 
+	assert.Equal(t, cfgReloaded.GetActiveHost().Name, "https://app.transifex.com")
 	assert.Equal(t, cfgReloaded.GetActiveHost().Token, "apassword")
 	assert.Equal(t, cfgReloaded.GetActiveHost().RestHostname,
 		"https://rest.api.transifex.com")
@@ -283,9 +285,9 @@ func TestSuccessfulMigrationWithSourceFileConstruction(t *testing.T) {
 	defer f.Close()
 
 	_, err2 := f.WriteString(`
-		[https://app.transifex.com]
+		[https://www.transifex.com]
 		api_hostname  = https://api.transifex.com
-		hostname      = https://app.transifex.com
+		hostname      = https://www.transifex.com
 		username      = api
 		password      = apassword
 	`)
@@ -304,7 +306,7 @@ func TestSuccessfulMigrationWithSourceFileConstruction(t *testing.T) {
 
 	_, err2 = f.WriteString(`
 		[main]
-		host = https://app.transifex.com
+		host = https://www.transifex.com
 		[projslug.ares]
 		file_filter = locale/<lang>.po
 		minimum_perc = 0
@@ -330,7 +332,7 @@ func TestSuccessfulMigrationWithSourceFileConstruction(t *testing.T) {
 	assert.Equal(t, cfg.GetActiveHost().RestHostname, "")
 	assert.Equal(t, cfg.Local.Resources[0].OrganizationSlug, "")
 
-	_, err = MigrateLegacyConfigFile(&cfg, api)
+	_, _, err = MigrateLegacyConfigFile(&cfg, api)
 	if err != nil {
 		t.Error(err)
 	}
@@ -385,9 +387,9 @@ func TestNeedsTokenInRootConfig(t *testing.T) {
 	defer f.Close()
 
 	_, err2 := f.WriteString(`
-		[https://app.transifex.com]
+		[https://www.transifex.com]
 		api_hostname  = https://api.transifex.com
-		hostname      = https://app.transifex.com
+		hostname      = https://www.transifex.com
 		username      = tk
 		password      = apassword
 	`)
@@ -406,7 +408,7 @@ func TestNeedsTokenInRootConfig(t *testing.T) {
 
 	_, err2 = f.WriteString(`
 		[main]
-		host = https://app.transifex.com
+		host = https://www.transifex.com
 		[projslug.ares]
 		file_filter = locale/<lang>.po
 		minimum_perc = 0
@@ -431,7 +433,7 @@ func TestNeedsTokenInRootConfig(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	_, _ = MigrateLegacyConfigFile(&cfg, api)
+	_, _, _ = MigrateLegacyConfigFile(&cfg, api)
 
 	w.Close()
 	out, _ := ioutil.ReadAll(r)
@@ -451,12 +453,40 @@ func TestNoTransifexRcFile(t *testing.T) {
 			fmt.Println("Delete error:", err)
 		}
 	}
+
+	// Get user's home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	userTransifexRcPath := filepath.Join(homeDir, ".transifexrc")
+	userTransifexRcBackupPath := filepath.Join(homeDir, ".transifexrc.testbak")
+
+	// Check if user's .transifexrc exists and create a backup if needed
+	if _, err := os.Stat(userTransifexRcPath); err == nil {
+		err = os.Rename(userTransifexRcPath, userTransifexRcBackupPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Clean up any ~/.transifexrc that got created during the test, and restore the user's original
+	defer func() {
+		os.Remove(userTransifexRcPath)
+		if _, err = os.Stat(userTransifexRcBackupPath); err == nil {
+			err = os.Rename(userTransifexRcBackupPath, userTransifexRcPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
+
 	// Requests Data
 	mockData := jsonapi.MockData{
 		"/organizations": jsonapi.GetMockTextResponse(`{"data": []}`),
 	}
 
-	// Create deprecated config & .transifexrc
+	// Create deprecated config without .transifexrc
 	pkgDir, _ := os.Getwd()
 	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
@@ -479,7 +509,7 @@ func TestNoTransifexRcFile(t *testing.T) {
 
 	_, err2 := f.WriteString(`
 		[main]
-		host = https://app.transifex.com
+		host = https://www.transifex.com
 		[projslug.ares]
 		file_filter = locale/<lang>.po
 		minimum_perc = 0
@@ -503,12 +533,13 @@ func TestNoTransifexRcFile(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	_, _ = MigrateLegacyConfigFile(&cfg, api)
+	_, _, _ = MigrateLegacyConfigFile(&cfg, api)
 
 	w.Close()
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = rescueStdout
 
+	assert.True(t, strings.Contains(string(out), "Root configuration file not found"))
 	assert.True(t, strings.Contains(string(out), "Please provide an API token to continue."))
 }
 
@@ -606,9 +637,9 @@ func TestResourceMigrationFailed(t *testing.T) {
 	defer f.Close()
 
 	_, err2 := f.WriteString(`
-		[https://app.transifex.com]
+		[https://www.transifex.com]
 		api_hostname  = https://api.transifex.com
-		hostname      = https://app.transifex.com
+		hostname      = https://www.transifex.com
 		username      = api
 		password      = apassword
 	`)
@@ -627,7 +658,7 @@ func TestResourceMigrationFailed(t *testing.T) {
 
 	_, err2 = f.WriteString(`
 		[main]
-		host = https://app.transifex.com
+		host = https://www.transifex.com
 		[projslug1.ares]
 		file_filter = locale/<lang>.po
 		minimum_perc = 10
@@ -661,7 +692,7 @@ func TestResourceMigrationFailed(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	_, err = MigrateLegacyConfigFile(&cfg, api)
+	_, _, err = MigrateLegacyConfigFile(&cfg, api)
 	if err != nil {
 		t.Error(err)
 	}
@@ -686,7 +717,7 @@ func TestResourceMigrationFailed(t *testing.T) {
 		string(content), "minimum_perc = 0"))
 }
 
-func TestBackUpFileCreated(t *testing.T) {
+func TestBackUpFilesCreated(t *testing.T) {
 	var afterTest = func(pkgDir string, tmpDir string) {
 		err := os.Chdir(pkgDir)
 		if err != nil {
@@ -747,9 +778,9 @@ func TestBackUpFileCreated(t *testing.T) {
 	defer f.Close()
 
 	_, err2 := f.WriteString(`
-		[https://app.transifex.com]
+		[https://www.transifex.com]
 		api_hostname  = https://api.transifex.com
-		hostname      = https://app.transifex.com
+		hostname      = https://www.transifex.com
 		username      = api
 		password      = apassword
 	`)
@@ -768,7 +799,7 @@ func TestBackUpFileCreated(t *testing.T) {
 
 	_, err2 = f.WriteString(`
 		[main]
-		host = https://app.transifex.com
+		host = https://www.transifex.com
 		[projslug.ares]
 		file_filter = locale/<lang>.po
 		minimum_perc = 0
@@ -789,22 +820,37 @@ func TestBackUpFileCreated(t *testing.T) {
 
 	api := jsonapi.GetTestConnection(mockData)
 
-	backupFilePath, _ := MigrateLegacyConfigFile(&cfg, api)
+	backupFilePath, backupRootFilePath, _ := MigrateLegacyConfigFile(&cfg, api)
 
-	newContent, err := ioutil.ReadFile(filepath.Join(tmpDir, "config"))
+	newLocalContent, err := ioutil.ReadFile(filepath.Join(tmpDir, "config"))
 	if err != nil {
 		t.Error(err)
 	}
-	buContent, err := ioutil.ReadFile(filepath.Join(backupFilePath))
+	buLocalContent, err := ioutil.ReadFile(filepath.Join(backupFilePath))
 	if err != nil {
 		t.Error(err)
 	}
 
-	if err != nil {
-		t.Errorf("A backup file was expected %s", err.Error())
+	newRootContent, err2 := ioutil.ReadFile(filepath.Join(tmpDir, ".transifexrc"))
+	if err2 != nil {
+		t.Error(err2)
+	}
+	buRootContent, err2 := ioutil.ReadFile(filepath.Join(backupRootFilePath))
+	if err2 != nil {
+		t.Error(err2)
 	}
 
-	assert.True(t, strings.Contains(string(buContent), "[projslug.ares]"))
-	assert.True(t, strings.Contains(string(newContent),
+	if err != nil {
+		t.Errorf("A backup local config file was expected %s", err.Error())
+	}
+
+	if err2 != nil {
+		t.Errorf("A backup root config file was expected %s", err2.Error())
+	}
+
+	assert.True(t, strings.Contains(string(buLocalContent), "[projslug.ares]"))
+	assert.True(t, strings.Contains(string(newLocalContent),
 		"o:org:p:projslug:r:ares"))
+	assert.True(t, strings.Contains(string(buRootContent), "[https://www.transifex.com]"))
+	assert.True(t, strings.Contains(string(newRootContent), "[https://app.transifex.com]"))
 }


### PR DESCRIPTION
This commit handles various flaws with `tx migrate` and improves the tests for the migration script. For example, it was previously possible to provide the API token and have it saved to `~/.transifexrc` yet `tx` commands continue prompting for it each time due to `www.transifex.com` not being changed to `app.transifex.com`.

I'll demonstrate my fix for these issues in each case below:

I. `~/.transifexrc` does not exist

Initial state:

```shell
[wclark@centos8-stream-wclark-katello-devel katello]$ cat .tx/config
[main]
host = https://www.transifex.com

[foreman.katello]
file_filter = locale/<lang>/katello.edit.po
source_file = locale/katello.pot
source_lang = en
type = PO

[foreman.bastion_katello]
file_filter = engines/bastion_katello/app/assets/javascripts/bastion_katello/i18n/locale/<lang>.po
source_file = engines/bastion_katello/app/assets/javascripts/bastion_katello/i18n/bastion_katello.pot
source_lang = en
type = PO

[wclark@centos8-stream-wclark-katello-devel katello]$ ll ~/.transifexrc
ls: cannot access '/home/wclark/.transifexrc': No such file or directory
```

Running the migration script:

```shell
[wclark@centos8-stream-wclark-katello-devel katello]$ ../transifex-cli/bin/tx migrate
Root configuration file not found -- creating it at `/home/wclark/.transifexrc`.
Please provide an API token to continue.
If you don't have an API token, you can generate one in https://app.transifex.com/user/settings/api/
> ***REDACTED_API_TOKEN***
No rest_hostname found. Adding `rest.api.transifex.com`
Migration ended! We have created a backup file for your previous /home/wclark/katello/.tx/config at `/home/wclark/katello/.tx/config_20230427063500.bak`.
Additionally, we have created a new /home/wclark/.transifexrc with your token.
```

Final state:

```shell
[wclark@centos8-stream-wclark-katello-devel katello]$ cat .tx/config
[main]
host = https://app.transifex.com

[o:foreman:p:foreman:r:bastion_katello]
file_filter = engines/bastion_katello/app/assets/javascripts/bastion_katello/i18n/locale/<lang>.po
source_file = engines/bastion_katello/app/assets/javascripts/bastion_katello/i18n/bastion_katello.pot
source_lang = en
type        = PO

[o:foreman:p:foreman:r:katello]
file_filter = locale/<lang>/katello.edit.po
source_file = locale/katello.pot
source_lang = en
type        = PO

[wclark@centos8-stream-wclark-katello-devel katello]$ cat ~/.transifexrc
[https://app.transifex.com]
rest_hostname = https://rest.api.transifex.com
token         = ***REDACTED_API_TOKEN***
```

II. `~/.transifexrc` exists but it still has deprecated `www.transifex.com` config (initial `.tx/config` same as above), and `www.transifex.com` was not getting updated to `app.transifex.com`

Initial state:

```shell
[wclark@centos8-stream-wclark-katello-devel katello]$ cat ~/.transifexrc
[https://www.transifex.com]
hostname      = https://www.transifex.com
username      = api
password      = ***REDACTED_API_TOKEN***
```

Running the migration script:

```shell
[wclark@centos8-stream-wclark-katello-devel katello]$ ../transifex-cli/bin/tx migrate
Found API token in `/home/wclark/.transifexrc` file
No rest_hostname found. Adding `rest.api.transifex.com`
Migration ended! We have created a backup file for your previous /home/wclark/katello/.tx/config at `/home/wclark/katello/.tx/config_20230427065348.bak`.
Additionally, we have created a backup file for your previous /home/wclark/.transifexrc at `/home/wclark/.transifexrc_20230427065348.bak`.
```

Final state:

```shell
[wclark@centos8-stream-wclark-katello-devel katello]$ cat ~/.transifexrc
[https://app.transifex.com]
hostname      = https://www.transifex.com
username      = api
password      = ***REDACTED_API_TOKEN***
rest_hostname = https://rest.api.transifex.com
token         = ***REDACTED_API_TOKEN***
```

In this case, the `.tx/config` is migrated properly as expected (I didn't include the output, it's the same as above).

NOTE: `~/.transifexrc` has the addition of the `rest_hostname` and `token` like we expect, and also had `[https://www.transifex.com]` changed to `[https://api.transifex.com]` as required. As of this time, the `hostname`, `username`, and `password` are unchanged (but we could remove these as well, as they are no longer needed, and we created a backup of the original `~/.transifexrc` file anyway)

III. We also now properly handle the case where `~/.transifexrc` has already been fully updated to use the new configuration (i.e. the user already updated their config when working on a different repository) but the local `.tx/config` still needs migration... previously this would also continue prompting for API token each time because local config still has `host = https://www.transifex.com` so `GetActiveHost` always returned `nil`.

Initial state:

```shell
[wclark@centos8-stream-wclark-katello-devel katello]$ cat ~/.transifexrc
[https://app.transifex.com]
rest_hostname = https://rest.api.transifex.com
token         = ***REDACTED_API_TOKEN***
```

(Again, the initial `.tx/config` is the same as in the above cases)

Running the migration script:

```shell
[wclark@centos8-stream-wclark-katello-devel katello]$ ../transifex-cli/bin/tx migrate
Migration ended! We have created a backup file for your previous /home/wclark/katello/.tx/config at `/home/wclark/katello/.tx/config_20230427070639.bak`.
Additionally, we have created a backup file for your previous /home/wclark/.transifexrc at `/home/wclark/.transifexrc_20230427070639.bak`.
```

Final state:

`~/.transifexrc` is unchanged from the initial state (although we created a backup anyway) and `.tx/config` is properly migrated

IV. In addition to fixing the migration script to better handle all of the above cases, I also improved the tests for the migration script in the following ways:

1. Restore `www.transifex.com` to the pre-migration configs in the test
2. Test that `www.transifex.com` becomes `app.transifex.com` after running the migration
3. Ensure that when running tests locally, the developer's `~/.transifexrc` gets moved prior to `TestNoTransifexRcFile` so that it doesn't interfere with the test; following the test, the newly created `~/.transifexrc` gets deleted and the developer's original `~/.transifexrc` gets restored
4. Added additional assertions to test the backup `~/.transifexrc` functionality of `tx migrate`