### PR TITLE
Gluon 254 add source push flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,10 @@ fall back to taking the filesystem timestamp into account.
   file push and will instead be replaced. This can also be set on a
   per-resource level in the configuration file.
 
+- `--keep-transations`: If present, translations of source strings with the
+  same key whose content changes will not be discarded. This can also be set on
+  a per-resource level in the configuration file.
+
 ### Pulling Files from Transifex
 
 `tx pull` is used to pull language files (usually translation language files) from

--- a/README.md
+++ b/README.md
@@ -590,6 +590,11 @@ fall back to taking the filesystem timestamp into account.
   any time.
 - `--silent`: Reduce verbosity of the output.
 
+- `--replace-edited-strings`: If present, source strings that have been edited
+  (in the editor UI or via the API) will not be protected from this source
+  file push and will instead be replaced. This can also be set on a
+  per-resource level in the configuration file.
+
 ### Pulling Files from Transifex
 
 `tx pull` is used to pull language files (usually translation language files) from

--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -264,6 +264,11 @@ func Main() {
 						Usage: "Whether to replace source strings that have been edited in the " +
 							"meantime",
 					},
+					&cli.BoolFlag{
+						Name: "keep-translations",
+						Usage: "Whether to not discard translations if a source string with a " +
+							"pre-existing key changes",
+					},
 				},
 				Action: func(c *cli.Context) error {
 					cfg, err := config.LoadFromPaths(
@@ -346,6 +351,7 @@ func Main() {
 						Workers:              workers,
 						Silent:               c.Bool("silent"),
 						ReplaceEditedStrings: c.Bool("replace-edited-strings"),
+						KeepTranslations:     c.Bool("keep-translations"),
 					}
 
 					if args.All && len(args.Languages) > 0 {

--- a/cmd/tx/main.go
+++ b/cmd/tx/main.go
@@ -259,6 +259,11 @@ func Main() {
 						Name:  "silent",
 						Usage: "Whether to reduce verbosity of the output",
 					},
+					&cli.BoolFlag{
+						Name: "replace-edited-strings",
+						Usage: "Whether to replace source strings that have been edited in the " +
+							"meantime",
+					},
 				},
 				Action: func(c *cli.Context) error {
 					cfg, err := config.LoadFromPaths(
@@ -327,19 +332,20 @@ func Main() {
 					}
 
 					args := txlib.PushCommandArguments{
-						Source:           c.Bool("source"),
-						Translation:      c.Bool("translation"),
-						Force:            c.Bool("force"),
-						Skip:             c.Bool("skip"),
-						Xliff:            c.Bool("xliff"),
-						Languages:        languages,
-						ResourceIds:      resourceIds,
-						UseGitTimestamps: c.Bool("use-git-timestamps"),
-						Branch:           c.String("branch"),
-						Base:             c.String("base"),
-						All:              c.Bool("all"),
-						Workers:          workers,
-						Silent:           c.Bool("silent"),
+						Source:               c.Bool("source"),
+						Translation:          c.Bool("translation"),
+						Force:                c.Bool("force"),
+						Skip:                 c.Bool("skip"),
+						Xliff:                c.Bool("xliff"),
+						Languages:            languages,
+						ResourceIds:          resourceIds,
+						UseGitTimestamps:     c.Bool("use-git-timestamps"),
+						Branch:               c.String("branch"),
+						Base:                 c.String("base"),
+						All:                  c.Bool("all"),
+						Workers:              workers,
+						Silent:               c.Bool("silent"),
+						ReplaceEditedStrings: c.Bool("replace-edited-strings"),
 					}
 
 					if args.All && len(args.Languages) > 0 {

--- a/internal/txlib/config/local.go
+++ b/internal/txlib/config/local.go
@@ -33,6 +33,7 @@ type Resource struct {
 	MinimumPercentage    int
 	ResourceName         string
 	ReplaceEditedStrings bool
+	KeepTranslations     bool
 }
 
 func loadLocalConfig() (*LocalConfig, error) {
@@ -132,6 +133,16 @@ func loadLocalConfigFromBytes(data []byte) (*LocalConfig, error) {
 			}
 		}
 
+		keepTranslations := false
+		if section.HasKey("keep_translations") {
+			keepTranslations, err = section.Key("keep_translations").Bool()
+			if err != nil {
+				return nil, fmt.Errorf(
+					"'keep_translations' needs to be 'true' or 'false': %s", err,
+				)
+			}
+		}
+
 		resource := Resource{
 			OrganizationSlug:     organizationSlug,
 			ProjectSlug:          projectSlug,
@@ -145,6 +156,7 @@ func loadLocalConfigFromBytes(data []byte) (*LocalConfig, error) {
 			MinimumPercentage:    -1,
 			ResourceName:         section.Key("resource_name").String(),
 			ReplaceEditedStrings: replaceEditedStrings,
+			KeepTranslations:     keepTranslations,
 		}
 
 		// Get first the perc in string to check if exists because .Key returns
@@ -297,6 +309,10 @@ func (localCfg LocalConfig) saveToWriter(file io.Writer) error {
 
 		section.NewKey(
 			"replace_edited_strings", strconv.FormatBool(resource.ReplaceEditedStrings),
+		)
+
+		section.NewKey(
+			"keep_translations", strconv.FormatBool(resource.KeepTranslations),
 		)
 	}
 

--- a/internal/txlib/push.go
+++ b/internal/txlib/push.go
@@ -31,6 +31,7 @@ type PushCommandArguments struct {
 	Workers              int
 	Silent               bool
 	ReplaceEditedStrings bool
+	KeepTranslations     bool
 }
 
 func PushCommand(
@@ -447,6 +448,7 @@ func (task *ResourcePushTask) Run(send func(string), abort func()) {
 			args,
 			resourceIsNew,
 			args.ReplaceEditedStrings || cfgResource.ReplaceEditedStrings,
+			args.KeepTranslations || cfgResource.KeepTranslations,
 		}
 	}
 	if args.Translation { // -t flag is set
@@ -574,6 +576,7 @@ type SourceFilePushTask struct {
 	args                 PushCommandArguments
 	resourceIsNew        bool
 	replaceEditedStrings bool
+	keepTranslations     bool
 }
 
 func (task *SourceFilePushTask) Run(send func(string), abort func()) {
@@ -584,6 +587,7 @@ func (task *SourceFilePushTask) Run(send func(string), abort func()) {
 	args := task.args
 	resourceIsNew := task.resourceIsNew
 	replaceEditedStrings := task.replaceEditedStrings
+	keepTranslations := task.keepTranslations
 
 	parts := strings.Split(resource.Id, ":")
 	sendMessage := func(body string, force bool) {
@@ -628,7 +632,9 @@ func (task *SourceFilePushTask) Run(send func(string), abort func()) {
 	err = handleThrottling(
 		func() error {
 			var err error
-			sourceUpload, err = txapi.UploadSource(api, resource, file, replaceEditedStrings)
+			sourceUpload, err = txapi.UploadSource(
+				api, resource, file, replaceEditedStrings, keepTranslations,
+			)
 			return err
 		},
 		"Uploading file",

--- a/pkg/jsonapi/resource.go
+++ b/pkg/jsonapi/resource.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"mime/multipart"
+	"strconv"
 )
 
 type Resource struct {
@@ -188,6 +189,11 @@ func (r *Resource) SaveAsMultipart(fields []string) error {
 			switch data := attribute.(type) {
 			case string:
 				err := writer.WriteField(field, data)
+				if err != nil {
+					return err
+				}
+			case bool:
+				err := writer.WriteField(field, strconv.FormatBool(data))
 				if err != nil {
 					return err
 				}

--- a/pkg/txapi/resource_strings_async_uploads.go
+++ b/pkg/txapi/resource_strings_async_uploads.go
@@ -36,7 +36,10 @@ func (err *ResourceStringAsyncUploadAttributes) Error() string {
 }
 
 func UploadSource(
-	api *jsonapi.Connection, resource *jsonapi.Resource, file io.Reader,
+	api *jsonapi.Connection,
+	resource *jsonapi.Resource,
+	file io.Reader,
+	replaceEditedStrings bool,
 ) (*jsonapi.Resource, error) {
 	data, err := io.ReadAll(file)
 	if err != nil {
@@ -49,7 +52,8 @@ func UploadSource(
 		// Setting attributes directly here because POST and GET attributes are
 		// different
 		Attributes: map[string]interface{}{
-			"content": data,
+			"content":                data,
+			"replace_edited_strings": replaceEditedStrings,
 		},
 	}
 	upload.SetRelated("resource", resource)

--- a/pkg/txapi/resource_strings_async_uploads.go
+++ b/pkg/txapi/resource_strings_async_uploads.go
@@ -40,6 +40,7 @@ func UploadSource(
 	resource *jsonapi.Resource,
 	file io.Reader,
 	replaceEditedStrings bool,
+	keepTranslations bool,
 ) (*jsonapi.Resource, error) {
 	data, err := io.ReadAll(file)
 	if err != nil {
@@ -54,6 +55,7 @@ func UploadSource(
 		Attributes: map[string]interface{}{
 			"content":                data,
 			"replace_edited_strings": replaceEditedStrings,
+			"keep_translations":      keepTranslations,
 		},
 	}
 	upload.SetRelated("resource", resource)


### PR DESCRIPTION
Adds the following two cli flags and config options:

- `--replace-edited-strings`
- `--keep-translations`

Either the flag or the option must be set for each flag to be into effect.

**Replace edited strings** will not protect source strings (that share a key with a pre-existing source string) that have been edited. For example,

1. Suppose we upload this file using the KEYVALUEJSON format

   ```json
   {"1": "one"}
   ```

2. Then we edit the source string in the Transifex editor to `one -> One`

3. Then we try to push the following file:

   ```json
   {"1": "ONE"}
   ```

Without the flag/option, Transifex will protect the edited version of the source string and nothing will change. If you want to discard all edits that have been done after the last push, you should use this flag/option

**Keep translations** will not discard translations when a source string (that shares a key with a pre-existing source string) changes. For example:

1. Suppose we upload this file using the KEYVALUEJSON format

   ```json
   {"1": "one"}
   ```

2. Then we translate this to `one -> ένα`

3. Then we try to push the following file:

   ```json
   {"1": "ONE"}
   ```

Without the flag/option, Transifex will discard the previous translation. If you want to keep it, you should use this flag/option.

**Important note:** The "keep translations" functionality has not been deployed to the Transifex API yet. This PR should not be merged/released before then.