### PR TITLE
Add Remote sources should skip  Native Projects

### DIFF
--- a/internal/txlib/add_remote.go
+++ b/internal/txlib/add_remote.go
@@ -72,10 +72,8 @@ func AddRemoteCommand(
 		}
 		i18nFormat, exists := i18nFormats[i18nFormatRelationship.DataSingular.Id]
 		if !exists {
-			return fmt.Errorf(
-				"could not find file Format: %s",
-				resource.Relationships["i18n_format"].DataSingular.Id,
-			)
+			fmt.Printf("Resource %s skipped: Invalid file Format %s\n", resource.Id, i18nFormatRelationship.DataSingular.Id)
+			continue
 		}
 
 		// Construct file-filter

--- a/internal/txlib/add_remote_test.go
+++ b/internal/txlib/add_remote_test.go
@@ -2,9 +2,11 @@ package txlib
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/transifex/cli/internal/txlib/config"
@@ -80,5 +82,81 @@ func TestAddRemote(t *testing.T) {
 	}}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Got request '%+v', expected '%+v'", actual, expected)
+	}
+}
+
+func TestAddRemoteInvalidFileFormat(t *testing.T) {
+	curDir, _ := os.Getwd()
+	tempDir, _ := os.MkdirTemp("", "")
+	defer os.RemoveAll(tempDir)
+	_ = os.Chdir(tempDir)
+	defer os.Chdir(curDir)
+
+	resourcesUrl := fmt.Sprintf(
+		"/resources?%s=%s",
+		url.QueryEscape("filter[project]"),
+		url.QueryEscape(projectId),
+	)
+	i18nFormatsUrl := fmt.Sprintf(
+		"/i18n_formats?%s=%s",
+		url.QueryEscape("filter[organization]"),
+		url.QueryEscape("o:orgslug"),
+	)
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	mockData := jsonapi.MockData{
+		projectUrl: getProjectEndpoint(),
+		resourcesUrl: jsonapi.GetMockTextResponse(
+			`{"data": [{
+				"type": "resources",
+				"id": "o:orgslug:p:projslug:r:resslug",
+				"attributes": {"slug": "resslug"},
+				"relationships": {
+					"i18n_format": {"data": {"type": "i18n_formats", "id": "FILELESS"}}
+				}
+			}]}`,
+		),
+		i18nFormatsUrl: jsonapi.GetMockTextResponse(
+			`{"data": [{
+				"type": "i18n_formats",
+				"id": "PO",
+				"attributes": {"file_extensions": [".po"]}
+			}]}`,
+		),
+	}
+
+	api := jsonapi.GetTestConnection(mockData)
+	cfg := &config.Config{Local: &config.LocalConfig{}}
+
+	err := AddRemoteCommand(
+		cfg,
+		&api,
+		"https://app.transifex.com/orgslug/projslug/whatever/whatever/",
+		// Lets make the file filter a bit weird
+		"locale/<project_slug><project_slug>.<resource_slug>/<lang>.<ext>",
+		50,
+	)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	// Restore stdout
+	w.Close()
+	os.Stdout = oldStdout
+	out, _ := ioutil.ReadAll(r)
+	r.Close()
+
+	testSimpleGet(t, mockData, projectUrl)
+	testSimpleGet(t, mockData, resourcesUrl)
+	testSimpleGet(t, mockData, i18nFormatsUrl)
+
+	// Check if the expected error message was printed
+	expectedErrorMessage := "Resource o:orgslug:p:projslug:r:resslug skipped: Invalid file Format FILELESS"
+	if !strings.Contains(string(out), expectedErrorMessage) {
+		t.Errorf("Expected error message '%s' not found in printed output", expectedErrorMessage)
 	}
 }


### PR DESCRIPTION
When attempting to add remote sources, if a fileless native project is included, an error is currently thrown, and the rest valid projects are not added to the configuration eventually. To address this issue, we can implement a solution to skip these invalid projects gracefully, allowing the addition of remote sources for the valid projects without disruption.