### PR TITLE
Poling translations infinite loop fix

### DIFF
--- a/pkg/txapi/resource_translations_async_downloads.go
+++ b/pkg/txapi/resource_translations_async_downloads.go
@@ -49,6 +49,11 @@ func PollTranslationDownload(download *jsonapi.Resource, filePath string) error 
 		}
 		if download.Redirect != "" {
 			break
+		} else if download.Attributes["status"] == "failed" {
+			return fmt.Errorf(
+				"download of translation '%s' failed",
+				download.Relationships["resource"].DataSingular.Id,
+			)
 		}
 	}
 	resp, err := http.Get(download.Redirect)


### PR DESCRIPTION
If downloading translations fails due to reasons such as the inability to create the downloaded file the  "redirect" field in the response is empty and status of task failed. An infinite loop can occur.
Based on backoff functionality, a request will be retried after 1s, 1s, 1s, 2s, 3s, 5s, 8s, 13s and then after 13s forever To avoid this we can break the loop if task's status is failed
