### PR TITLE
Truncate long messages

### DIFF
--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -153,12 +153,19 @@ func (task *ResourcePullTask) Run(send func(string), abort func()) {
 		if args.Silent && !force {
 			return
 		}
-		send(fmt.Sprintf(
+
+		message := fmt.Sprintf(
 			"%s.%s - %s",
 			cfgResource.ProjectSlug,
 			cfgResource.ResourceSlug,
 			body,
-		))
+		)
+
+		if !args.Silent {
+			message = truncateMessage(message)
+		}
+
+		send(message)
 	}
 	sendMessage("Getting info", false)
 
@@ -364,13 +371,20 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 		}
 
 		cyan := color.New(color.FgCyan).SprintFunc()
-		send(fmt.Sprintf(
+
+		message := fmt.Sprintf(
 			"%s.%s %s - %s",
 			cfgResource.ProjectSlug,
 			cfgResource.ResourceSlug,
 			cyan("["+code+"]"),
 			body,
-		))
+		)
+
+		if !args.Silent {
+			message = truncateMessage(message)
+		}
+
+		send(message)
 	}
 	sendMessage("Pulling file", false)
 

--- a/internal/txlib/push.go
+++ b/internal/txlib/push.go
@@ -279,12 +279,16 @@ func (task *ResourcePushTask) Run(send func(string), abort func()) {
 		if args.Silent && !force {
 			return
 		}
-		send(fmt.Sprintf(
+		message := fmt.Sprintf(
 			"%s.%s - %s",
 			cfgResource.ProjectSlug,
 			cfgResource.ResourceSlug,
 			body,
-		))
+		)
+		if !args.Silent {
+			message = truncateMessage(message)
+		}
+		send(message)
 	}
 	sendMessage("Getting info", false)
 	resource, err := txapi.GetResourceById(api, cfgResource.GetAPv3Id())
@@ -542,12 +546,16 @@ func (task *LanguagePushTask) Run(send func(string), abort func()) {
 		if args.Silent && !force {
 			return
 		}
-		send(fmt.Sprintf(
+		message := fmt.Sprintf(
 			"%s (%s) - %s",
 			parts[3],
 			strings.Join(languages, ", "),
 			body,
-		))
+		)
+		if !args.Silent {
+			message = truncateMessage(message)
+		}
+		send(message)
 	}
 	sendMessage("Pushing", false)
 
@@ -594,7 +602,12 @@ func (task *SourceFilePushTask) Run(send func(string), abort func()) {
 		if args.Silent && !force {
 			return
 		}
-		send(fmt.Sprintf("%s.%s - %s", parts[3], parts[5], body))
+
+		message := fmt.Sprintf("%s.%s - %s", parts[3], parts[5], body)
+		if !args.Silent {
+			message = truncateMessage(message)
+		}
+		send(message)
 	}
 
 	file, err := os.Open(sourceFile)
@@ -693,10 +706,14 @@ func (task *TranslationFileTask) Run(send func(string), abort func()) {
 		if args.Silent && !force {
 			return
 		}
-		send(fmt.Sprintf(
+		message := fmt.Sprintf(
 			"%s.%s %s - %s", parts[3], parts[5],
 			cyan("["+languageCode+"]"), body,
-		))
+		)
+		if !args.Silent {
+			message = truncateMessage(message)
+		}
+		send(message)
 	}
 
 	// Only check timestamps if -f isn't set and if resource isn't new

--- a/internal/txlib/utils.go
+++ b/internal/txlib/utils.go
@@ -210,3 +210,11 @@ func isValidResolutionPolicy(policy string) (IsValid bool) {
 	return false
 
 }
+
+func truncateMessage(message string) string {
+	maxLength := 80
+	if len(message) > maxLength {
+		return message[:maxLength-2] + ".."
+	}
+	return message
+}

--- a/internal/txlib/utils_test.go
+++ b/internal/txlib/utils_test.go
@@ -80,3 +80,27 @@ func TestConflictResolution(t *testing.T) {
 	}
 
 }
+
+func TestTruncateMessage(t *testing.T) {
+	result := truncateMessage("short message")
+	assert.Equal(t, result, "short message")
+
+	result = truncateMessage(
+		"this is a long message that needs to be truncated because it exceeds " +
+			"the maximum length of 75 characters",
+	)
+	assert.Equal(
+		t,
+		result,
+		"this is a long message that needs to be truncated because it exceeds the maxim..",
+	)
+
+	result = truncateMessage(
+		"a message with exactly 75 characters - this message should not be truncated",
+	)
+	assert.Equal(
+		t,
+		result,
+		"a message with exactly 75 characters - this message should not be truncated",
+	)
+}

--- a/pkg/txapi/resource_strings_async_downloads.go
+++ b/pkg/txapi/resource_strings_async_downloads.go
@@ -69,7 +69,7 @@ func PollResourceStringsDownload(download *jsonapi.Resource, filePath string) er
 			return nil
 		} else if download.Attributes["status"] == "failed" {
 			return fmt.Errorf(
-				"download of translation '%s' failed",
+				"failed to download translation '%s'",
 				download.Relationships["resource"].DataSingular.Id,
 			)
 

--- a/pkg/txapi/resource_strings_async_uploads.go
+++ b/pkg/txapi/resource_strings_async_uploads.go
@@ -84,7 +84,7 @@ func PollSourceUpload(upload *jsonapi.Resource) error {
 
 		if uploadAttributes.Status == "failed" {
 			// Wrap the "error"
-			return fmt.Errorf("upload of resource '%s' failed - %w",
+			return fmt.Errorf("failed to upload of resource '%s' - %w",
 				upload.Relationships["resource"].DataSingular.Id,
 				&uploadAttributes)
 		} else if uploadAttributes.Status == "succeeded" {

--- a/pkg/txapi/resource_translations_async_downloads.go
+++ b/pkg/txapi/resource_translations_async_downloads.go
@@ -51,7 +51,7 @@ func PollTranslationDownload(download *jsonapi.Resource, filePath string) error 
 			break
 		} else if download.Attributes["status"] == "failed" {
 			return fmt.Errorf(
-				"download of translation '%s' failed",
+				"failed to download translation '%s'",
 				download.Relationships["resource"].DataSingular.Id,
 			)
 		}

--- a/pkg/txapi/resource_translations_async_uploads.go
+++ b/pkg/txapi/resource_translations_async_uploads.go
@@ -88,7 +88,7 @@ func PollTranslationUpload(upload *jsonapi.Resource) error {
 		if uploadAttributes.Status == "failed" {
 			// Wrap the "error"
 			return fmt.Errorf(
-				"upload of resource '%s', language '%s' failed - %w",
+				"failed to upload resource '%s', language '%s' - %w",
 				upload.Relationships["resource"].DataSingular.Id,
 				upload.Relationships["language"].DataSingular.Id,
 				&uploadAttributes)


### PR DESCRIPTION
We utilize [uilive](https://github.com/gosuri/uilive)  library to update the terminal output in real-time during task execution. Due to the nature of uilive,  multi-line errors retuned by service calls aren't always displayed accurately within the tasks section, leading to confusion, particularly during multitasking scenarios. 
We can truncate long messages in these cases and print the entire messages in --silent flag cases where the terminal output is not updated in real time.