### PR TITLE
Extend retry mechanism for specific api errors

### DIFF
--- a/internal/txlib/merge.go
+++ b/internal/txlib/merge.go
@@ -109,7 +109,7 @@ func (task *MergeResourcePollTask) Run(send func(string), abort func()) {
 		))
 	}
 
-	err := handleThrottling(
+	err := handleRetry(
 		func() error {
 			return txapi.PollResourceMerge(
 				merge,

--- a/internal/txlib/pull.go
+++ b/internal/txlib/pull.go
@@ -409,7 +409,7 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 		// Creating download job
 
 		var download *jsonapi.Resource
-		err = handleThrottling(
+		err = handleRetry(
 			func() error {
 				var err error
 				download, err = txapi.CreateResourceStringsAsyncDownload(
@@ -434,7 +434,7 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 
 		// Polling
 
-		err = handleThrottling(
+		err = handleRetry(
 			func() error {
 				return txapi.PollResourceStringsDownload(download, sourceFile)
 			},
@@ -513,7 +513,7 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 		// Creating download job
 
 		var download *jsonapi.Resource
-		err = handleThrottling(
+		err = handleRetry(
 			func() error {
 				var err error
 				if args.Pseudo {
@@ -549,7 +549,7 @@ func (task *FilePullTask) Run(send func(string), abort func()) {
 
 		// Polling
 
-		err = handleThrottling(
+		err = handleRetry(
 			func() error {
 				return txapi.PollTranslationDownload(download, filePath)
 			},

--- a/internal/txlib/push.go
+++ b/internal/txlib/push.go
@@ -629,7 +629,7 @@ func (task *SourceFilePushTask) Run(send func(string), abort func()) {
 	// Uploading file
 
 	var sourceUpload *jsonapi.Resource
-	err = handleThrottling(
+	err = handleRetry(
 		func() error {
 			var err error
 			sourceUpload, err = txapi.UploadSource(
@@ -650,7 +650,7 @@ func (task *SourceFilePushTask) Run(send func(string), abort func()) {
 
 	// Polling
 
-	err = handleThrottling(
+	err = handleRetry(
 		func() error {
 			return txapi.PollSourceUpload(sourceUpload)
 		},
@@ -722,7 +722,7 @@ func (task *TranslationFileTask) Run(send func(string), abort func()) {
 	// Uploading file
 
 	var upload *jsonapi.Resource
-	err := handleThrottling(
+	err := handleRetry(
 		func() error {
 			var err error
 			upload, err = pushTranslation(
@@ -742,7 +742,7 @@ func (task *TranslationFileTask) Run(send func(string), abort func()) {
 	}
 
 	// Polling
-	err = handleThrottling(
+	err = handleRetry(
 		func() error {
 			return txapi.PollTranslationUpload(upload)
 		},

--- a/internal/txlib/utils.go
+++ b/internal/txlib/utils.go
@@ -153,11 +153,11 @@ func makeRemoteToLocalLanguageMappings(
 }
 
 /*
-Run 'do'. If the error returned by 'do' is a jsonapi.ThrottleError, sleep the number of
+Run 'do'. If the error returned by 'do' is a jsonapi.RetryError, sleep the number of
 seconds indicated by the error and try again. Meanwhile, inform the user of
 what's going on using 'send'.
 */
-func handleThrottling(do func() error, initialMsg string, send func(string)) error {
+func handleRetry(do func() error, initialMsg string, send func(string)) error {
 	for {
 		if len(initialMsg) > 0 {
 			send(initialMsg)
@@ -166,13 +166,13 @@ func handleThrottling(do func() error, initialMsg string, send func(string)) err
 		if err == nil {
 			return nil
 		} else {
-			var e *jsonapi.ThrottleError
+			var e *jsonapi.RetryError
 			if errors.As(err, &e) {
 				retryAfter := e.RetryAfter
 				if isatty.IsTerminal(os.Stdout.Fd()) {
 					for retryAfter > 0 {
 						send(fmt.Sprintf(
-							"Throttled, will retry after %d seconds",
+							"will retry after %d seconds",
 							retryAfter,
 						))
 						time.Sleep(time.Second)
@@ -180,7 +180,7 @@ func handleThrottling(do func() error, initialMsg string, send func(string)) err
 					}
 				} else {
 					send(fmt.Sprintf(
-						"Throttled, will retry after %d seconds",
+						"will retry after %d seconds",
 						retryAfter,
 					))
 					time.Sleep(time.Duration(retryAfter) * time.Second)

--- a/pkg/jsonapi/connection.go
+++ b/pkg/jsonapi/connection.go
@@ -65,9 +65,9 @@ func (c *Connection) request(
 	}
 	defer response.Body.Close()
 
-	throttleErrorResponse := parseThrottleResponse(response)
-	if throttleErrorResponse != nil {
-		return nil, throttleErrorResponse
+	retryErrorResponse := parseRetryResponse(response)
+	if retryErrorResponse != nil {
+		return nil, retryErrorResponse
 	}
 
 	errorResponse := parseErrorResponse(response.StatusCode, body)


### PR DESCRIPTION
Extend the existing functionality of throttling for responses 502/503/504 and retry requests