### PR TITLE
TX CLI pull job fails with a throttling message

### DIFF
--- a/internal/txlib/utils.go
+++ b/internal/txlib/utils.go
@@ -171,17 +171,15 @@ func handleRetry(do func() error, initialMsg string, send func(string)) error {
 				retryAfter := e.RetryAfter
 				if isatty.IsTerminal(os.Stdout.Fd()) {
 					for retryAfter > 0 {
-						send(fmt.Sprintf(
-							"will retry after %d seconds",
-							retryAfter,
+						send(fmt.Sprint(
+							err,
 						))
 						time.Sleep(time.Second)
 						retryAfter -= 1
 					}
 				} else {
-					send(fmt.Sprintf(
-						"will retry after %d seconds",
-						retryAfter,
+					send(fmt.Sprint(
+						err,
 					))
 					time.Sleep(time.Duration(retryAfter) * time.Second)
 				}


### PR DESCRIPTION
Add retry mechanism on the following requests (wrap the api call inside handleRetry function):
 - get resource 
 - create resource
 - get language statistics
 - get all languages

Improve the Retry error message printed  in the terminal 
 - Include the response code at printed message
 - in case of 502, 503, 504 response codes, a retryAfter header is not included in response, we can retry after 10 seconds instead of 1.

Output example:

![Screenshot 2024-06-18 at 2 52 39 PM](https://github.com/transifex/cli/assets/112862979/83ee5815-efa5-466a-ba3f-91cd2aa2d416)
