### PR TITLE
Replace --rm-dist with --clean flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TKN }}


### PR DESCRIPTION
It seems that --rm-dist flag is deprecated. Reference https://goreleaser.com/deprecations/#-rm-dist