### PR TITLE
Improve error messages length output in CLI

### DIFF
--- a/internal/txlib/utils.go
+++ b/internal/txlib/utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/transifex/cli/internal/txlib/config"
 	"github.com/transifex/cli/pkg/jsonapi"
+	"golang.org/x/term"
 )
 
 func figureOutBranch(branch string) string {
@@ -209,8 +210,21 @@ func isValidResolutionPolicy(policy string) (IsValid bool) {
 
 }
 
+type getSizeFuncType func(fd int) (int, int, error)
+
+var getSizeFunc getSizeFuncType = term.GetSize
+
 func truncateMessage(message string) string {
-	maxLength := 80
+	width, _, err := getSizeFunc(int(os.Stdout.Fd()))
+	if err != nil {
+		width = 80
+	}
+
+	maxLength := width - 2
+	if maxLength < 0 {
+		maxLength = 0
+	}
+
 	if len(message) > maxLength {
 		return message[:maxLength-2] + ".."
 	}

--- a/internal/txlib/utils_test.go
+++ b/internal/txlib/utils_test.go
@@ -67,32 +67,27 @@ func TestFigureOutResources(t *testing.T) {
 	}
 }
 
-func TestConflictResolution(t *testing.T) {
-	ResultHead := isValidResolutionPolicy("USE_HEAD")
-	assert.Equal(t, ResultHead, true)
-
-	ResultBase := isValidResolutionPolicy("USE_BASE")
-	assert.Equal(t, ResultBase, true)
-
-	WrongResult := isValidResolutionPolicy("WRONG_BASE")
-	if WrongResult == true {
-		t.Error("Should be error")
-	}
-
+func mockGetSize(fd int) (int, int, error) {
+	return 80, 0, nil
 }
 
 func TestTruncateMessage(t *testing.T) {
+	// Backup the original function
+	originalGetSizeFunc := getSizeFunc
+	defer func() { getSizeFunc = originalGetSizeFunc }()
+
+	// Test with 80 character terminal width
+	getSizeFunc = mockGetSize
 	result := truncateMessage("short message")
-	assert.Equal(t, result, "short message")
+	assert.Equal(t, "short message", result)
 
 	result = truncateMessage(
-		"this is a long message that needs to be truncated because it exceeds " +
-			"the maximum length of 75 characters",
+		"this is a long message that needs to be truncated because it exceeds the maximum length of 75 characters",
 	)
 	assert.Equal(
 		t,
+		"this is a long message that needs to be truncated because it exceeds the max..",
 		result,
-		"this is a long message that needs to be truncated because it exceeds the maxim..",
 	)
 
 	result = truncateMessage(
@@ -100,7 +95,7 @@ func TestTruncateMessage(t *testing.T) {
 	)
 	assert.Equal(
 		t,
-		result,
 		"a message with exactly 75 characters - this message should not be truncated",
+		result,
 	)
 }


### PR DESCRIPTION
Get the term's width to truncate message's length