### PR TITLE
feat: add XDG Base Directory Specification support

### DIFF
--- a/internal/txlib/config/main.go
+++ b/internal/txlib/config/main.go
@@ -46,7 +46,7 @@ type Config struct {
 /*
 Load Transifex configuration from the usual paths:
 
-- ~/.transifexrc for the root configuration
+- $XDG_CONFIG_HOME/transifex/transifexrc (or ~/.config/transifex/transifexrc if XDG_CONFIG_HOME is not set) for the root configuration, with fallback to ~/.transifexrc for legacy support
 
 - ./.tx/config for the local configuration
 

--- a/internal/txlib/config/root.go
+++ b/internal/txlib/config/root.go
@@ -92,6 +92,11 @@ func (rootCfg *RootConfig) save() error {
 }
 
 func (rootCfg *RootConfig) saveToPath() error {
+	dir := filepath.Dir(rootCfg.Path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
 	file, err := os.OpenFile(rootCfg.Path,
 		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
 		0755)
@@ -204,5 +209,21 @@ func GetRootPath() (string, error) {
 		}
 		homeDir = usr.HomeDir
 	}
-	return filepath.Join(homeDir, ".transifexrc"), nil
+
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome == "" {
+		xdgConfigHome = filepath.Join(homeDir, ".config")
+	}
+
+	xdgPath := filepath.Join(xdgConfigHome, "transifex", "transifexrc")
+	if _, err := os.Stat(xdgPath); err == nil {
+		return xdgPath, nil
+	}
+
+	legacyPath := filepath.Join(homeDir, ".transifexrc")
+	if _, err := os.Stat(legacyPath); err == nil {
+		return legacyPath, nil
+	}
+
+	return xdgPath, nil
 }

--- a/internal/txlib/credentials.go
+++ b/internal/txlib/credentials.go
@@ -107,24 +107,27 @@ func GetHostAndToken(
 			// for the hostname
 			token = selectedHost.Token
 		} else {
-			fmt.Println("API token not found. Please provide it and it will " +
-				"be saved in '~/.transifexrc'.")
-			fmt.Println("If you don't have an API token, you can generate " +
-				"one in https://app.transifex.com/user/settings/api/")
-			fmt.Print("> ")
-			_, err := fmt.Scanln(&token)
-			if err != nil {
-				return "", "", err
-			}
-
+			rootConfigPath := ""
 			if cfg.Root == nil {
-				rootConfigPath, err := config.GetRootPath()
+				var err error
+				rootConfigPath, err = config.GetRootPath()
 				if err != nil {
 					return "", "", err
 				}
 				cfg.Root = &config.RootConfig{
 					Path: rootConfigPath,
 				}
+			} else {
+				rootConfigPath = cfg.Root.Path
+			}
+
+			fmt.Printf("API token not found. Please provide it and it will be saved in '%s'.\n", rootConfigPath)
+			fmt.Println("If you don't have an API token, you can generate " +
+				"one in https://app.transifex.com/user/settings/api/")
+			fmt.Print("> ")
+			_, err := fmt.Scanln(&token)
+			if err != nil {
+				return "", "", err
 			}
 			cfg.Root.Hosts = append(cfg.Root.Hosts, config.Host{
 				Name:         hostname,

--- a/internal/txlib/migrate.go
+++ b/internal/txlib/migrate.go
@@ -66,8 +66,7 @@ func MigrateLegacyConfigFile(
 		} else {
 			// No token for some reason get a new one
 			if cfg.GetActiveHost() != nil {
-				fmt.Println("API token not found. Please provide it and it will " +
-					"be saved in '~/.transifexrc'.")
+				fmt.Printf("API token not found. Please provide it and it will be saved in '%s'.\n", cfg.Root.Path)
 			} else {
 				fmt.Println("Please provide an API token to continue.")
 			}


### PR DESCRIPTION
it's the de-facto standard for storing user data and config on UNIX.

references:
- https://specifications.freedesktop.org/basedir/basedir-spec-latest.html
- https://wiki.archlinux.org/title/XDG_Base_Directory

Search for the config file in the following order:

1. $XDG_CONFIG_HOME/transifex/transifexrc
2. ~/.config/transifex/transifexrc
3. ~/.transifexrc