### PR TITLE
TX-17248: Generate Go coverage profile for SonarQube (prep)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cli
 .DS_Store
 local_example/
 .envrc
+coverage.out

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-go test -cover ./...
+# -coverprofile writes a machine-readable profile (coverage.out) for SonarQube
+# (sonar.go.coverage.reportPaths); -covermode=atomic keeps counts correct under
+# concurrent tests. Profile entries are module-import paths, resolved by the
+# scanner from the module root (sonar.sources=.).
+go test -covermode=atomic -coverprofile=coverage.out ./...

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+# SonarQube configuration for the Transifex CLI (Go).
+# Scan is run from the module root so the import paths in coverage.out resolve.
+#
+# NOTE: the CI step that runs the scanner is NOT wired up yet. The internal
+# Sonar host (sonar.svc.transifex.net) is unreachable from GitHub-hosted
+# runners, so the host + runner choice (self-hosted runner vs SonarCloud) is a
+# follow-up. sonar.host.url and the auth token are supplied by that CI step,
+# not here.
+sonar.projectKey=cli
+sonar.sources=.
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.exclusions=**/*_test.go,**/vendor/**,examples/**,build/**
+sonar.go.coverage.reportPaths=coverage.out


### PR DESCRIPTION
Related to [TX-17248: Provide Transifex test coverage metrics](https://transifex.atlassian.net/browse/TX-17248)

## Problem

The CLI has **no SonarQube integration**, and `go test -cover ./...` only prints per-package percentages to stdout — it writes no machine-readable profile. So there is nothing a scanner could ingest, and the repo cannot report coverage.

## What this PR does (prep)

- **`scripts/tests.sh`**: generate a coverage profile — `go test -covermode=atomic -coverprofile=coverage.out ./...` (was `-cover`). `atomic` keeps counts correct under concurrent tests; `./...` writes one merged profile across all packages.
- **`sonar-project.properties`** (new): Go scan config rooted at the module so import paths resolve — `sonar.sources=.`, tests declared via `**/*_test.go`, and `sonar.go.coverage.reportPaths=coverage.out`.
- **`.gitignore`**: ignore `coverage.out`.

`scripts/tests.cmd` (Windows) is left on `-cover` on purpose — the profile only needs to be produced by the one CI OS that uploads it.

## What is intentionally deferred

**The CI step that runs the scanner is not wired up in this PR.** This repo runs on **GitHub Actions**, and the internal Sonar host `sonar.svc.transifex.net` is an in-cluster address that GitHub-hosted runners can't reach. So the host + runner decision is a follow-up:

- **Option A — self-hosted runner → internal Sonar** (keeps the CLI on the same server as the rest of the org's licence). Add to the `ubuntu-latest` test job in `.github/workflows/test.yml`, after tests:
  ```yaml
  - name: SonarQube Scan
    uses: sonarsource/sonarqube-scan-action@v4
    env:
      SONAR_HOST_URL: https://sonar.svc.transifex.net
      SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
  ```
  (job must run on a self-hosted runner label with network access to the host; `coverage.out` must already exist from the test step)

- **Option B — SonarCloud** (works from GitHub-hosted runners; separate server from the internal instance): same action with `SONAR_HOST_URL: https://sonarcloud.io` + a `sonar.organization` in `sonar-project.properties`.

Generating coverage from a single OS (`ubuntu-latest`) is recommended to avoid Windows path-separator differences in the profile.

## How to test

Verified locally that the new command produces a valid merged Go profile:

```
$ go test -covermode=atomic -coverprofile=coverage.out ./pkg/assert/... ./internal/txlib/config/...
$ head -1 coverage.out
mode: atomic
```

Entries are keyed by import path (`github.com/transifex/cli/pkg/assert/assert.go:...`), which the Sonar Go analyzer maps to files via the `go.mod` module path when the scan runs from the module root (`sonar.sources=.`). Full-suite generation happens via the existing `scripts/tests.sh` in CI.
